### PR TITLE
Add Flask web service and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Google Generative AI Text Generation Example
 
 This repository contains a tiny Python script demonstrating how to call Google's Gemini API using the `google-generativeai` library.
+It also includes a small role-playing game (RPG) demo that can be played either through the command line or via a web service.
 
 ## Setup
 
@@ -12,13 +13,25 @@ This repository contains a tiny Python script demonstrating how to call Google's
 
 ## Usage
 
-Run the script and provide a prompt when prompted:
+### Command-Line Demo
+
+Run the RPG demo interactively:
 
 ```bash
-python main.py
+python example_game.py
 ```
 
-The script sends your prompt to the `gemini-1.5-flash` model and prints the generated response.
+### Web Service
+
+Start a small Flask web service exposing the same game logic:
+
+```bash
+python web_service.py
+```
+Then open `http://127.0.0.1:5000/` in a browser. The page presents
+character choices as radio buttons. Select a character and submit to see
+possible questions, then choose a question and press **Send** to view the
+character's answer.
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 google-generativeai
 python-dotenv
+Flask

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from web_service import create_app
+from rpg.character import MarkdownCharacter
+
+FIXTURE = os.path.join(os.path.dirname(__file__), "fixtures", "test_character.md")
+
+
+class WebServiceTest(unittest.TestCase):
+    def test_html_flow(self):
+        with patch("rpg.character.genai") as mock_genai:
+            mock_model = MagicMock()
+            mock_model.generate_content.side_effect = [
+                MagicMock(text="Base context"),
+                MagicMock(text="1. Where are you?\n2. Who are you?\n3. What do you do?"),
+                MagicMock(text="I stand guard."),
+            ]
+            mock_genai.GenerativeModel.return_value = mock_model
+
+            character = MarkdownCharacter("Tester", FIXTURE)
+
+        with patch("web_service.load_characters", return_value=[character]):
+            app = create_app()
+            client = app.test_client()
+
+            resp = client.get("/")
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn("Tester", resp.data.decode())
+
+            resp = client.post("/questions", data={"character": "0"})
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn("Where are you?", resp.data.decode())
+
+            resp = client.post(
+                "/answer", data={"character": "0", "question": "Where are you?"}
+            )
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn("I stand guard.", resp.data.decode())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web_service.py
+++ b/web_service.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import List
+
+from flask import Flask, request
+
+from example_game import load_characters
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+    characters = load_characters()
+
+    @app.route("/", methods=["GET"])
+    def list_characters() -> str:
+        options = "".join(
+            f'<input type="radio" name="character" value="{idx}" id="char{idx}">'
+            f'<label for="char{idx}">{char.name}</label><br>'
+            for idx, char in enumerate(characters)
+        )
+        return (
+            "<form method='post' action='/questions'>"
+            f"{options}"
+            "<button type='submit'>Choose</button>"
+            "</form>"
+        )
+
+    @app.route("/questions", methods=["POST"])
+    def character_questions() -> str:
+        char_id = int(request.form["character"])
+        char = characters[char_id]
+        questions: List[str] = char.generate_questions()
+        radios = "".join(
+            f'<input type="radio" name="question" value="{q}" id="q{idx}">'
+            f'<label for="q{idx}">{q}</label><br>'
+            for idx, q in enumerate(questions)
+        )
+        return (
+            "<form method='post' action='/answer'>"
+            f"{radios}"
+            f"<input type='hidden' name='character' value='{char_id}'>"
+            "<button type='submit'>Send</button>"
+            "</form>"
+        )
+
+    @app.route("/answer", methods=["POST"])
+    def character_answer() -> str:
+        char_id = int(request.form["character"])
+        question = request.form["question"]
+        char = characters[char_id]
+        answer = char.answer_question(question)
+        return f"<p>{answer}</p>"
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run()


### PR DESCRIPTION
## Summary
- add Flask web service exposing RPG character interactions
- cover web service with unit test
- document CLI and web service usage

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_character.py tests/test_web_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd44b4fccc833393ab6d0e3bad1838