### PR TITLE
Allow configuring web service port and host

### DIFF
--- a/web_service.py
+++ b/web_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import List
+import os
 
 from flask import Flask, request
 
@@ -57,4 +58,4 @@ def create_app() -> Flask:
 
 if __name__ == "__main__":
     app = create_app()
-    app.run()
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 7860)))


### PR DESCRIPTION
## Summary
- bind Flask app to 0.0.0.0 and configurable PORT env var
- import `os` for port lookup

## Testing
- `pytest tests/test_character.py tests/test_web_service.py tests/test_gcp_example.py -q`
- `docker build -t rpg-app .` *(fails: no Dockerfile found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd67612eb48333910e844ed7a9f96f