### PR TITLE
Redirect to character selection and show action history

### DIFF
--- a/example_game.py
+++ b/example_game.py
@@ -29,8 +29,7 @@ def main() -> None:
     for idx, act in enumerate(options, 1):
         print(f"{idx}. {act}")
     action = options[int(input("Choose an action: ")) - 1]
-    result, scores = char.perform_action(action, state.history)
-    print(result)
+    scores = char.perform_action(action, state.history)
     state.record_action(char, action, scores)
 
 

--- a/rpg/character.py
+++ b/rpg/character.py
@@ -1,7 +1,8 @@
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 """Character abstractions backed by folder-defined context."""
 
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
 import os
 from abc import ABC, abstractmethod
 from typing import Any, List, Tuple
@@ -14,10 +15,23 @@ except ModuleNotFoundError:  # pragma: no cover
     genai = None
 
 
+logger = logging.getLogger(__name__)
+
+
 class Character(ABC):
     """Abstract base class defining character interactions."""
 
     def __init__(self, name: str, context: str, model: str = "gemini-2.5-flash"):
+        """Initialize a character.
+
+        Args:
+            name: Character name.
+            context: Base context used for prompt generation.
+            model: Generative model identifier.
+
+        Returns:
+            None.
+        """
         self.name = name
         self.context = context
         if genai is None:  # pragma: no cover - env without dependency
@@ -26,19 +40,43 @@ class Character(ABC):
 
     @abstractmethod
     def generate_actions(self, history: List[Tuple[str, str]]) -> List[str]:
-        """Return three possible actions a player might request."""
+        """Return three possible actions a player might request.
+
+        Args:
+            history: Prior actions taken in the game.
+
+        Returns:
+            A list of up to three proposed actions.
+        """
 
     @abstractmethod
     def perform_action(
         self, action: str, history: List[Tuple[str, str]]
-    ) -> Tuple[str, List[int]]:
-        """Return result of performing ``action`` and triplet progress."""
+    ) -> List[int]:
+        """Assess progress after performing ``action``.
+
+        Args:
+            action: The requested action to perform.
+            history: Prior actions taken in the game.
+
+        Returns:
+            Updated progress scores for the character.
+        """
 
 
 class FolderCharacter(Character):
     """Character defined by a folder containing context and yaml lists."""
 
     def __init__(self, folder: str, model: str = "gemini-2.5-flash"):
+        """Load character data from ``folder``.
+
+        Args:
+            folder: Directory containing character definition files.
+            model: Generative model identifier.
+
+        Returns:
+            None.
+        """
         name = os.path.basename(folder.rstrip(os.sep))
 
         md_files = [f for f in os.listdir(folder) if f.endswith(".md")]
@@ -64,6 +102,11 @@ class FolderCharacter(Character):
         self.base_context = base_context
 
     def _triplet_text(self) -> str:
+        """Return a textual representation of triplet data.
+
+        Returns:
+            A multi-line string describing current, condition, and gap.
+        """
         lines = []
         for idx, (cur, cond, gap) in enumerate(self.triplets, 1):
             gap_text = gap if isinstance(gap, str) else gap.get("explanation", str(gap))
@@ -73,15 +116,26 @@ class FolderCharacter(Character):
         return "\n".join(lines)
 
     def _history_text(self, history: List[Tuple[str, str]]) -> str:
+        """Format the action history into a readable string.
+
+        Args:
+            history: List of (actor, action) tuples.
+
+        Returns:
+            A multi-line string of past actions or 'None' if empty.
+        """
         return "\n".join(f"{actor}: {act}" for actor, act in history) or "None"
 
     def generate_actions(self, history: List[Tuple[str, str]]) -> List[str]:
+        logger.info("Generating actions for %s", self.name)
         prompt = (
             f"{self.base_context}\n{self._triplet_text()}\n"
             f"Previous actions:\n{self._history_text(history)}\n"
             "List three numbered actions you might take next."
         )
+        logger.debug("Prompt: %s", prompt)
         response = self._model.generate_content(prompt)
+        logger.debug("Response: %s", getattr(response, "text", ""))
         lines = [line.strip() for line in response.text.splitlines() if line.strip()]
         actions: List[str] = []
         for line in lines:
@@ -98,21 +152,20 @@ class FolderCharacter(Character):
 
     def perform_action(
         self, action: str, history: List[Tuple[str, str]]
-    ) -> Tuple[str, List[int]]:
+    ) -> List[int]:
+        logger.info("Performing action '%s' for %s", action, self.name)
         full_history = history + [(self.name, action)]
         context_block = (
             f"{self.base_context}\n{self._triplet_text()}\n"
             f"Action history:\n{self._history_text(full_history)}\n"
         )
-        action_prompt = f"{context_block}Player requests: {action}\n{self.name}:"
-        response = self._model.generate_content(action_prompt)
-        result = response.text.strip()
-
         assess_prompt = (
             f"{context_block}"
             "Provide progress (0-100) for each triplet on separate lines."
         )
+        logger.debug("Assess prompt: %s", assess_prompt)
         assess_resp = self._model.generate_content(assess_prompt)
+        logger.debug("Assess response: %s", getattr(assess_resp, "text", ""))
         scores: List[int] = []
         for line in assess_resp.text.splitlines():
             line = line.strip()
@@ -124,4 +177,4 @@ class FolderCharacter(Character):
             scores.append(max(0, min(100, int(num))))
             if len(scores) == len(self.triplets):
                 break
-        return result, scores
+        return scores

--- a/rpg/game_state.py
+++ b/rpg/game_state.py
@@ -5,10 +5,14 @@
 from __future__ import annotations
 
 import os
+import logging
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
 from .character import Character
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -21,6 +25,12 @@ class GameState:
     how_to_win: str = field(init=False)
 
     def __post_init__(self) -> None:
+        """Initialize progress tracking and load "how to win" instructions.
+
+        Returns:
+            None.
+        """
+        logger.info("Initializing game state")
         self.progress = {c.name: [0] * len(c.triplets) for c in self.characters}
         win_path = os.path.join(os.path.dirname(__file__), "..", "how-to-win.md")
         with open(win_path, "r", encoding="utf-8") as f:
@@ -29,7 +39,17 @@ class GameState:
     def record_action(
         self, character: Character, action: str, scores: List[int]
     ) -> None:
-        """Record that ``character`` performed ``action`` and update progress."""
+        """Record an action and associated scores.
+
+        Args:
+            character: The actor performing the action.
+            action: The action undertaken.
+            scores: Updated progress scores for the actor.
+        
+        Returns:
+            None.
+        """
+        logger.info("Recording action '%s' for %s", action, character.name)
         self.history.append((character.name, action))
         if character.name in self.progress:
             current = self.progress[character.name]
@@ -38,7 +58,14 @@ class GameState:
                     current[idx] = score
 
     def render_state(self) -> str:
-        lines = []
-        for name, scores in self.progress.items():
-            lines.append(f"{name}: {scores}")
+        """Return HTML rendering of the current game state.
+
+        Returns:
+            HTML string describing character progress and history.
+        """
+        logger.info("Rendering game state")
+        lines = [f"{name}: {scores}" for name, scores in self.progress.items()]
+        if self.history:
+            lines.append("History:")
+            lines.extend(f"{n}: {a}" for n, a in self.history)
         return "<div id='state'>" + "<br>".join(lines) + "</div>"

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -17,7 +17,6 @@ class FolderCharacterTest(unittest.TestCase):
         mock_model = MagicMock()
         mock_model.generate_content.side_effect = [
             MagicMock(text="1. Act1\n2. Act2\n3. Act3"),
-            MagicMock(text="Done."),
             MagicMock(text="10\n20\n30"),
         ]
         mock_genai.GenerativeModel.return_value = mock_model
@@ -25,8 +24,7 @@ class FolderCharacterTest(unittest.TestCase):
         char = FolderCharacter(FIXTURE_DIR)
         actions = char.generate_actions([])
         self.assertEqual(len(actions), 3)
-        result, scores = char.perform_action(actions[0], [])
-        self.assertEqual(result, "Done.")
+        scores = char.perform_action(actions[0], [])
         self.assertEqual(scores, [10, 20, 30])
 
 

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -15,11 +15,11 @@ FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "test_characte
 
 class WebServiceTest(unittest.TestCase):
     def test_html_flow(self):
+        """Ensure the web flow renders pages and records history."""
         with patch("rpg.character.genai") as mock_genai:
             mock_model = MagicMock()
             mock_model.generate_content.side_effect = [
                 MagicMock(text="1. A\n2. B\n3. C"),
-                MagicMock(text="Result."),
                 MagicMock(text="10\n20\n30"),
             ]
             mock_genai.GenerativeModel.return_value = mock_model
@@ -42,12 +42,14 @@ class WebServiceTest(unittest.TestCase):
             self.assertIn("id='state'", page)
 
             resp = client.post(
-                "/perform", data={"character": "0", "action": "A"}
+                "/perform", data={"character": "0", "action": "A"}, follow_redirects=True
             )
             page = resp.data.decode()
             self.assertEqual(resp.status_code, 200)
-            self.assertIn("Result.", page)
+            self.assertEqual(resp.request.path, "/")
             self.assertIn("[10, 20, 30]", page)
+            self.assertIn("History:", page)
+            self.assertIn("test_character: A", page)
 
 
 if __name__ == "__main__":

--- a/web_service.py
+++ b/web_service.py
@@ -5,21 +5,45 @@
 from __future__ import annotations
 
 from typing import List
+import logging
 import os
 
-from flask import Flask, request
+from flask import Flask, request, redirect, Response
 
 from example_game import load_characters
 from rpg.game_state import GameState
 
 
+logger = logging.getLogger(__name__)
+
+
 def create_app() -> Flask:
-    """Create and configure the Flask application."""
+    """Return a configured Flask application ready to serve the game.
+
+    Returns:
+        The configured Flask application.
+    """
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
     app = Flask(__name__)
     game_state = GameState(load_characters())
 
+    @app.before_request
+    def log_request() -> None:
+        """Log the HTTP method and path for incoming requests.
+
+        Returns:
+            None.
+        """
+        logger.info("%s %s", request.method, request.path)
+
     @app.route("/", methods=["GET"])
     def list_characters() -> str:
+        """Display available characters and current game state.
+
+        Returns:
+            HTML string listing characters and state.
+        """
+        logger.info("Listing characters")
         options = "".join(
             f'<input type="radio" name="character" value="{idx}" id="char{idx}">'\
             f'<label for="char{idx}">{char.name}</label><br>'
@@ -35,9 +59,16 @@ def create_app() -> Flask:
 
     @app.route("/actions", methods=["POST"])
     def character_actions() -> str:
+        """Show actions for the selected character.
+
+        Returns:
+            HTML string listing possible actions.
+        """
         char_id = int(request.form["character"])
+        logger.info("Generating actions for character %d", char_id)
         char = game_state.characters[char_id]
         actions: List[str] = char.generate_actions(game_state.history)
+        logger.debug("Actions: %s", actions)
         radios = "".join(
             f'<input type="radio" name="action" value="{a}" id="a{idx}">'\
             f'<label for="a{idx}">{a}</label><br>'
@@ -54,13 +85,20 @@ def create_app() -> Flask:
         )
 
     @app.route("/perform", methods=["POST"])
-    def character_perform() -> str:
+    def character_perform() -> Response:
+        """Carry out a character action and redirect to the main page.
+
+        Returns:
+            A redirect response to the root page.
+        """
         char_id = int(request.form["character"])
         action = request.form["action"]
+        logger.info("Performing action '%s' for character %d", action, char_id)
         char = game_state.characters[char_id]
-        result, scores = char.perform_action(action, game_state.history)
+        scores = char.perform_action(action, game_state.history)
+        logger.debug("Scores: %s", scores)
         game_state.record_action(char, action, scores)
-        return f"<p>{result}</p>{game_state.render_state()}"
+        return redirect("/")
 
     return app
 


### PR DESCRIPTION
## Summary
- Redirect /perform route back to the character selection screen after recording an action
- Display an action history beneath the game state
- Log incoming requests, character actions, and debug prompts/responses
- Document function inputs and outputs across modules
- Simplify `perform_action` to rely solely on the assessment prompt and return progress scores

## Testing
- `GEMINI_API_KEY='' pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdf4d3de208333ae8a8aec9624adf0