### PR TITLE
Allow LOG_LEVEL to configure logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ character choices as radio buttons. Select a character and submit to see
 possible actions, then choose an action and press **Send** to view the
 character's response.
 
+### Logging
+
+Both entry points respect the `LOG_LEVEL` environment variable to control
+verbosity. Set `LOG_LEVEL=DEBUG` for more detailed output. The default
+level is `INFO`.
+
 ## License
 
 This project is licensed under the terms of the [GNU General Public License

--- a/example_game.py
+++ b/example_game.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
 import os
 from typing import List
 
@@ -20,6 +21,7 @@ def load_characters() -> List[FolderCharacter]:
 
 
 def main() -> None:
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
     state = GameState(load_characters())
     for idx, char in enumerate(state.characters, 1):
         print(f"{idx}. {char.name}")


### PR DESCRIPTION
## Summary
- allow configuring CLI demo logging via `LOG_LEVEL` env var with INFO default
- document logging level control for both entry points

## Testing
- `pytest tests/test_character.py tests/test_web_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf97079608333b730bc6723e3c1ce