### PR TITLE
Refactor triplet naming and add weighted scoring

### DIFF
--- a/characters.yaml
+++ b/characters.yaml
@@ -1,10 +1,10 @@
 Governments:
-  conditions:
+  end_states:
     - Impose compute caps and enforce reporting
     - Create empowered AI oversight agencies
     - Negotiate international agreements for verification and enforcement
     - Shift national security framing from AGI race to Tool AI programs
-  current_state:
+  initial_states:
     - Political focus on economic growth and national security competition
     - Oversight agencies limited or nonexistent
     - Export controls exist but no international treaties on AI compute
@@ -28,12 +28,12 @@ Governments:
     - **Interactions**: Strongly influenced by corporate lobbying; in rivalry with other governments (e.g., US–China), affecting chipmakers and regulators.
 
 Corporations:
-  conditions:
+  end_states:
     - Accept strict liability for dangerous systems
     - Comply with compute oversight and hard caps
     - Pivot business models from AGI toward Tool AI
     - Respond to cultural and social pressure to change mission
-  current_state:
+  initial_states:
     - Corporations resist regulation, opposing liability frameworks such as California’s SB1047
     - Currently maximize compute use in pursuit of AGI capabilities
     - Business incentives favor labor-replacing AGI systems
@@ -58,12 +58,12 @@ Corporations:
     - **Interactions**: Depend on hardware manufacturers for chips; heavily influence governments and regulators.
 
 HardwareManufacturers:
-  conditions:
+  end_states:
     - Embed governance features in chips (cryptographic locks, metering, geolocation)
     - Cooperate with government oversight and reporting schemes
     - Support global standards without loopholes
     - Accept reduced sales in exchange for stability and safety
-  current_state:
+  initial_states:
     - Highly concentrated supply chain (TSMC, ASML, NVIDIA, AMD) makes oversight feasible
     - Some export controls in place (e.g., US restrictions to China)
     - No global harmonized standards; unilateral controls create loopholes
@@ -87,11 +87,11 @@ HardwareManufacturers:
     - **Interactions**: Depend on government mandates for governance; affected by geopolitical rivalries between governments.
 
 Regulators:
-  conditions:
+  end_states:
     - Stay independent from corporate and national capture
     - Develop clear technical standards for compute reporting and accounting
     - Create legitimate global governance institutions
-  current_state:
+  initial_states:
     - Industry lobbying strongly influences rulemaking; EU AI Act exempts military AI and does not prohibit AGI
     - Early standards like Frontier Model Forum exist but lack enforcement
     - No global AI governance body exists; only proposals for CERN/IAEA-style institutions
@@ -113,11 +113,11 @@ Regulators:
     - **Interactions**: Vulnerable to corporate capture; depend on governments for legitimacy and on international cooperation for enforcement.
 
 CivilSociety:
-  conditions:
+  end_states:
     - Be well-informed on AGI risks and Tool AI alternatives
     - Build broad coalitions across NGOs, labor, and media
     - Exert democratic leverage early to influence policy
-  current_state:
+  initial_states:
     - Public polls show opposition to AGI but understanding of risks is shallow
     - NGOs exist (Future of Life Institute, alignment groups) but fragmented and weak relative to corporations
     - Institutions weak; lobbying power of corporations outweighs public preference
@@ -139,11 +139,11 @@ CivilSociety:
     - **Interactions**: Influence governments and regulators through democratic processes; need to build coalitions with scientists and media.
 
 ScientificCommunity:
-  conditions:
+  end_states:
     - Resist corporate funding capture
     - Coordinate globally to prevent 'safety tourism'
     - Engage public and policymakers with credible advocacy
-  current_state:
+  initial_states:
     - Many researchers absorbed by big tech labs; independent research underfunded
     - Some collaboration among AI safety networks but fragmented
     - Prominent researchers (Hinton, Bengio) actively warn of extinction risks

--- a/tests/fixtures/characters.yaml
+++ b/tests/fixtures/characters.yaml
@@ -1,15 +1,18 @@
 test_character:
   MarkdownContext: |
     Base context for test character.
-  conditions:
-    - condition1
-    - condition2
-    - condition3
-  current_state:
-    - current1
-    - current2
-    - current3
+  end_states:
+    - end1
+    - end2
+    - end3
+  initial_states:
+    - initial1
+    - initial2
+    - initial3
   gaps:
-    - gap1
-    - gap2
-    - gap3
+    - severity: Small
+      explanation: gap1
+    - severity: Moderate
+      explanation: gap2
+    - severity: Large
+      explanation: gap3

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -34,7 +34,8 @@ class YamlCharacterTest(unittest.TestCase):
         char = YamlCharacter("test_character", data["test_character"])
         actions = char.generate_actions([])
         prompt_used = mock_action_model.generate_content.call_args_list[0][0][0]
-        self.assertIn("condition1", prompt_used)
+        self.assertIn("end1", prompt_used)
+        self.assertIn("size: Small", prompt_used)
         self.assertIn("aligned with your motivations and capabilities", prompt_used)
         self.assertEqual(len(actions), 3)
         assessor = AssessmentAgent()

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -16,8 +16,51 @@ FIXTURE_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "characters.y
 
 
 class WebServiceTest(unittest.TestCase):
-    def test_html_flow(self):
-        """Ensure the web flow renders pages and records history."""
+    def test_win_and_reset_flow(self):
+        with patch("rpg.character.genai") as mock_char_genai, patch(
+            "rpg.assessment_agent.genai"
+        ) as mock_assess_genai:
+            mock_action_model = MagicMock()
+            mock_assess_model = MagicMock()
+            mock_action_model.generate_content.return_value = MagicMock(
+                text="1. A\n2. B\n3. C"
+            )
+            mock_assess_model.generate_content.return_value = MagicMock(
+                text="90\n90\n90"
+            )
+            mock_char_genai.GenerativeModel.return_value = mock_action_model
+            mock_assess_genai.GenerativeModel.return_value = mock_assess_model
+            with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
+                data = yaml.safe_load(fh)
+            character = YamlCharacter("test_character", data["test_character"])
+            with patch("web_service.load_characters", return_value=[character]):
+                app = create_app()
+                client = app.test_client()
+
+        resp = client.get("/")
+        page = resp.data.decode()
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("Reset", page)
+
+        resp = client.post(
+            "/perform", data={"character": "0", "action": "A"}, follow_redirects=True
+        )
+        page = resp.data.decode()
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.request.path, "/result")
+        self.assertIn("You won!", page)
+        self.assertIn("History:", page)
+        self.assertIn("test_character: A", page)
+        self.assertIn("Final weighted score", page)
+        self.assertIn("Reset", page)
+
+        resp = client.post("/reset", follow_redirects=True)
+        page = resp.data.decode()
+        self.assertEqual(resp.request.path, "/")
+        self.assertIn("Final weighted score: 0", page)
+        self.assertNotIn("History:", page)
+
+    def test_loss_after_ten_actions(self):
         with patch("rpg.character.genai") as mock_char_genai, patch(
             "rpg.assessment_agent.genai"
         ) as mock_assess_genai:
@@ -34,32 +77,25 @@ class WebServiceTest(unittest.TestCase):
             with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
                 data = yaml.safe_load(fh)
             character = YamlCharacter("test_character", data["test_character"])
-
             with patch("web_service.load_characters", return_value=[character]):
                 app = create_app()
                 client = app.test_client()
 
-            resp = client.get("/")
-            page = resp.data.decode()
-            self.assertEqual(resp.status_code, 200)
-            self.assertIn("test_character", page)
-            self.assertIn("[0, 0, 0]", page)
-
-            resp = client.post("/actions", data={"character": "0"})
-            page = resp.data.decode()
-            self.assertEqual(resp.status_code, 200)
-            self.assertIn("A", page)
-            self.assertIn("id='state'", page)
-
+        for _ in range(9):
             resp = client.post(
                 "/perform", data={"character": "0", "action": "A"}, follow_redirects=True
             )
-            page = resp.data.decode()
-            self.assertEqual(resp.status_code, 200)
             self.assertEqual(resp.request.path, "/")
-            self.assertIn("[10, 20, 30]", page)
-            self.assertIn("History:", page)
-            self.assertIn("test_character: A", page)
+
+        resp = client.post(
+            "/perform", data={"character": "0", "action": "A"}, follow_redirects=True
+        )
+        page = resp.data.decode()
+        self.assertEqual(resp.request.path, "/result")
+        self.assertIn("You lost!", page)
+        self.assertIn("History:", page)
+        self.assertIn("Final weighted score", page)
+        self.assertIn("Reset", page)
 
 
 if __name__ == "__main__":

--- a/web_service.py
+++ b/web_service.py
@@ -56,6 +56,9 @@ def create_app() -> Flask:
             f"{options}"
             "<button type='submit'>Choose</button>"
             "</form>"
+            "<form method='post' action='/reset'>"
+            "<button type='submit'>Reset</button>"
+            "</form>"
             f"{game_state.render_state()}"
         )
 
@@ -83,6 +86,9 @@ def create_app() -> Flask:
             "<button type='submit'>Send</button>"
             "</form>"
             "<a href='/'>Back to characters</a>"
+            "<form method='post' action='/reset'>"
+            "<button type='submit'>Reset</button>"
+            "</form>"
             f"{game_state.render_state()}"
         )
 
@@ -101,7 +107,30 @@ def create_app() -> Flask:
         scores = assessor.assess(game_state.characters, game_state.how_to_win, game_state.history)
         logger.debug("Scores: %s", scores)
         game_state.update_progress(scores)
+        final_score = game_state.final_weighted_score()
+        if final_score >= 80 or len(game_state.history) >= 10:
+            return redirect("/result")
         return redirect("/")
+
+    @app.route("/reset", methods=["POST"])
+    def reset() -> Response:
+        """Reset the game to its initial state."""
+        nonlocal game_state
+        game_state = GameState(load_characters())
+        return redirect("/")
+
+    @app.route("/result", methods=["GET"])
+    def result() -> str:
+        """Display the final game outcome."""
+        final = game_state.final_weighted_score()
+        outcome = "You won!" if final >= 80 else "You lost!"
+        return (
+            f"<h1>{outcome}</h1>"
+            f"{game_state.render_state()}"
+            "<form method='post' action='/reset'>"
+            "<button type='submit'>Reset</button>"
+            "</form>"
+        )
 
     return app
 


### PR DESCRIPTION
## Summary
- rename triplet keys to `initial_states` and `end_states`
- include gap size when showing triplets and pre-compute severity weights
- compute weighted progress per actor and overall game score with final weighted score display
- add reset button, end-game detection, and results page with history

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c098225c2483338252bab574c6d8c5