### PR TITLE
Add player instructions and site links

### DIFF
--- a/rpg/game_state.py
+++ b/rpg/game_state.py
@@ -101,7 +101,7 @@ class GameState:
             for name, scores in self.progress.items()
         ]
         if self.history:
-            lines.append("History:")
+            lines.append("<h2>Action History</h2>")
             lines.extend(f"{n}: {a}" for n, a in self.history)
         lines.append(f"Final weighted score: {self.final_weighted_score()}")
         return "<div id='state'>" + "<br>".join(lines) + "</div>"

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -49,7 +49,7 @@ class WebServiceTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.request.path, "/result")
         self.assertIn("You won!", page)
-        self.assertIn("History:", page)
+        self.assertIn("Action History", page)
         self.assertIn("test_character: A", page)
         self.assertIn("Final weighted score", page)
         self.assertIn("Reset", page)
@@ -58,7 +58,7 @@ class WebServiceTest(unittest.TestCase):
         page = resp.data.decode()
         self.assertEqual(resp.request.path, "/")
         self.assertIn("Final weighted score: 0", page)
-        self.assertNotIn("History:", page)
+        self.assertNotIn("Action History", page)
 
     def test_loss_after_ten_actions(self):
         with patch("rpg.character.genai") as mock_char_genai, patch(
@@ -93,7 +93,7 @@ class WebServiceTest(unittest.TestCase):
         page = resp.data.decode()
         self.assertEqual(resp.request.path, "/result")
         self.assertIn("You lost!", page)
-        self.assertIn("History:", page)
+        self.assertIn("Action History", page)
         self.assertIn("Final weighted score", page)
         self.assertIn("Reset", page)
 

--- a/web_service.py
+++ b/web_service.py
@@ -52,6 +52,9 @@ def create_app() -> Flask:
             for idx, char in enumerate(game_state.characters)
         )
         return (
+            "<h1>AI Safety Negotiation Game</h1>"
+            "<p>You are an expert negotiator with connection to all relevant actors in the AI safety world, you can convince them to propose and take actions.  your objective is to enure that ai is developed in the best interest of humanity. your goal is to keep the future human.</p>"
+            "<p>You have 10 turns to reach a final weighted score of 80 or higher to win.</p>"
             "<form method='post' action='/actions'>"
             f"{options}"
             "<button type='submit'>Choose</button>"
@@ -60,6 +63,7 @@ def create_app() -> Flask:
             "<button type='submit'>Reset</button>"
             "</form>"
             f"{game_state.render_state()}"
+            "<footer><a href='https://github.com/balazsbme/keep-the-future-human-survival-rpg'>GitHub Repository</a></footer>"
         )
 
     @app.route("/actions", methods=["POST"])
@@ -80,6 +84,8 @@ def create_app() -> Flask:
             for idx, a in enumerate(actions)
         )
         return (
+            f"<h1>Choose Action for {char.name}</h1>"
+            "<p>Select an action and click Send.</p>"
             "<form method='post' action='/perform'>"
             f"{radios}"
             f"<input type='hidden' name='character' value='{char_id}'>"
@@ -90,6 +96,7 @@ def create_app() -> Flask:
             "<button type='submit'>Reset</button>"
             "</form>"
             f"{game_state.render_state()}"
+            "<footer><a href='https://github.com/balazsbme/keep-the-future-human-survival-rpg'>GitHub Repository</a></footer>"
         )
 
     @app.route("/perform", methods=["POST"])
@@ -130,6 +137,7 @@ def create_app() -> Flask:
             "<form method='post' action='/reset'>"
             "<button type='submit'>Reset</button>"
             "</form>"
+            "<footer><a href='https://github.com/balazsbme/keep-the-future-human-survival-rpg'>GitHub Repository</a></footer>"
         )
 
     return app


### PR DESCRIPTION
## Summary
- Add introductory context and win conditions to the start page with a footer linking to the GitHub repo
- Provide action selection instructions and GitHub link on each page
- Render action history under an HTML header for clearer state display

## Testing
- `pytest tests/test_character.py tests/test_web_service.py`
- Attempted `pytest` (hangs in `test_genai_example.py`)


------
https://chatgpt.com/codex/tasks/task_e_68c1e5fb01f48333848f550d57e3afa5