### PR TITLE
Add optional threaded parallelism for web service

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ character choices as radio buttons. Select a character and submit to see
 possible actions, then choose an action and press **Send** to view the
 character's response.
 
+Set the environment variable `ENABLE_PARALLELISM=1` to run the web
+service with experimental threading support. When enabled the server
+pre-generates character actions and performs progress assessments in the
+background, improving responsiveness.
+
 ### Logging
 
 Both entry points respect the `LOG_LEVEL` environment variable to control

--- a/rpg/assessment_agent.py
+++ b/rpg/assessment_agent.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Tuple
 
 try:  # pragma: no cover - optional dependency
@@ -26,13 +28,65 @@ class AssessmentAgent:
         """
         if genai is None:  # pragma: no cover - environment without dependency
             raise ModuleNotFoundError("google-generativeai not installed")
-        self._model = genai.GenerativeModel(model)
+        # Store the genai module reference so patched versions persist per instance
+        self._genai = genai
+        # keep only the model name and create a per-thread model on demand
+        self._model_name = model
+        self._local = threading.local()
+
+    def _get_model(self):
+        """Return a thread-local GenerativeModel instance."""
+        if not hasattr(self._local, "model"):
+            self._local.model = self._genai.GenerativeModel(self._model_name)
+        return self._local.model
+
+    def _assess_single(
+        self,
+        char: Character,
+        actor_list: str,
+        how_to_win: str,
+        history_text: str,
+    ) -> List[int]:
+        """Assess ``char`` returning a list of progress scores.
+
+        This helper exists so assessments for multiple characters can be
+        executed in parallel using threads when requested by the caller.
+        """
+
+        context = f"{char.base_context}\n{char._triplet_text()}"
+        prompt = (
+            "You are the Game Master for the 'Keep the future human' survival RPG. "
+            "The player is interacting with the characters and convinces them to take actions. "
+            f"You assess of the following character's 'initial state - end state - gap' triplets with a 0-100 integer: {actor_list}, "
+            "based on the baseline script and the performed actions.\n"
+            f"The baseline script: {how_to_win}\n"
+            f"Performed actions: {history_text}\n"
+            f"Assess all triplets of the character {context}.\n"
+            "Output ONLY an ordered list of 0-100 integers one for each triplet line-by-line."
+        )
+        logger.debug("Assessment prompt for %s: %s", char.name, prompt)
+        response = self._get_model().generate_content(prompt)
+        text = getattr(response, "text", "")
+        logger.info("Assessment for %s: %s", char.name, text[:50])
+        scores: List[int] = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            num = ''.join(ch for ch in line if ch.isdigit())
+            if not num:
+                continue
+            scores.append(max(0, min(100, int(num))))
+            if len(scores) == len(char.triplets):
+                break
+        return scores
 
     def assess(
         self,
         characters: List[Character],
         how_to_win: str,
         history: List[Tuple[str, str]],
+        parallel: bool = False,
     ) -> Dict[str, List[int]]:
         """Assess all triplets for each character.
 
@@ -40,39 +94,29 @@ class AssessmentAgent:
             characters: List of game characters.
             how_to_win: Baseline script content.
             history: List of (actor, action) tuples performed so far.
+            parallel: If ``True``, perform per-character assessments concurrently
+                using threads.
 
         Returns:
             Mapping of character name to list of progress scores.
         """
+
         actor_list = ", ".join(c.name for c in characters)
         history_text = "\n".join(f"{actor}: {act}" for actor, act in history) or "None"
+
+        if parallel:
+            with ThreadPoolExecutor(max_workers=len(characters)) as executor:
+                future_map = {
+                    executor.submit(
+                        self._assess_single, char, actor_list, how_to_win, history_text
+                    ): char.name
+                    for char in characters
+                }
+                return {name: fut.result() for fut, name in future_map.items()}
+
         results: Dict[str, List[int]] = {}
         for char in characters:
-            context = f"{char.base_context}\n{char._triplet_text()}"
-            prompt = (
-                "You are the Game Master for the 'Keep the future human' survival RPG. "
-                "The player is interacting with the characters and convinces them to take actions. "
-                f"You assess of the following character's 'initial state - end state - gap' triplets with a 0-100 integer: {actor_list}, "
-                "based on the baseline script and the performed actions.\n"
-                f"The baseline script: {how_to_win}\n"
-                f"Performed actions: {history_text}\n"
-                f"Assess all triplets of the character {context}.\n"
-                "Output ONLY an ordered list of 0-100 integers one for each triplet line-by-line."
+            results[char.name] = self._assess_single(
+                char, actor_list, how_to_win, history_text
             )
-            logger.debug("Assessment prompt for %s: %s", char.name, prompt)
-            response = self._model.generate_content(prompt)
-            text = getattr(response, "text", "")
-            logger.info("Assessment for %s: %s", char.name, text[:50])
-            scores: List[int] = []
-            for line in text.splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                num = ''.join(ch for ch in line if ch.isdigit())
-                if not num:
-                    continue
-                scores.append(max(0, min(100, int(num))))
-                if len(scores) == len(char.triplets):
-                    break
-            results[char.name] = scores
         return results

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,83 @@
+import os
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from web_service import create_app
+from rpg.character import YamlCharacter
+
+FIXTURE_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "characters.yaml")
+
+
+@patch.dict(os.environ, {"ENABLE_PARALLELISM": "1"})
+@patch("rpg.assessment_agent.genai")
+@patch("rpg.character.genai")
+def test_async_action_generation(mock_char_genai, mock_assess_genai):
+    mock_char_genai.GenerativeModel.return_value = MagicMock()
+    mock_assess_genai.GenerativeModel.return_value = MagicMock()
+    with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    character = YamlCharacter("test_character", data["test_character"])
+
+    start_evt = threading.Event()
+    finish_evt = threading.Event()
+
+    def slow_actions(history):
+        start_evt.set()
+        finish_evt.wait()
+        return ["A"]
+
+    with patch.object(character, "generate_actions", side_effect=slow_actions):
+        with patch("web_service.load_characters", return_value=[character]):
+            app = create_app()
+            client = app.test_client()
+            client.get("/")
+            assert start_evt.wait(timeout=1)
+            resp = client.post("/actions", data={"character": "0"})
+            assert b"Loading" in resp.data
+            finish_evt.set()
+            time.sleep(0.1)
+            resp = client.post("/actions", data={"character": "0"})
+            assert b"A" in resp.data
+
+
+@patch.dict(os.environ, {"ENABLE_PARALLELISM": "1"})
+@patch("rpg.assessment_agent.genai")
+@patch("rpg.character.genai")
+def test_assessment_background_wait(mock_char_genai, mock_assess_genai):
+    mock_char_genai.GenerativeModel.return_value = MagicMock()
+    mock_assess_genai.GenerativeModel.return_value = MagicMock()
+    with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    character = YamlCharacter("test_character", data["test_character"])
+
+    start_evt = threading.Event()
+    finish_evt = threading.Event()
+
+    with patch.object(character, "generate_actions", return_value=["A"]):
+        class DummyAssess:
+            def assess(self, chars, htw, hist, parallel=False):
+                start_evt.set()
+                finish_evt.wait()
+                return {c.name: [100] * len(c.triplets) for c in chars}
+
+        with patch("web_service.AssessmentAgent", return_value=DummyAssess()):
+            with patch("web_service.load_characters", return_value=[character]):
+                app = create_app()
+                client = app.test_client()
+                client.get("/")
+                resp = client.post(
+                    "/perform", data={"character": "0", "action": "A"}
+                )
+                assert resp.status_code == 302
+                assert start_evt.wait(timeout=1)
+                resp = client.get("/result")
+                assert b"Waiting for assessments" in resp.data
+                finish_evt.set()
+                time.sleep(0.1)
+                resp = client.get("/result")
+                assert b"You won" in resp.data

--- a/web_service.py
+++ b/web_service.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 import logging
 import os
+import threading
+import queue
 
 from flask import Flask, request, redirect, Response
 
@@ -26,8 +28,16 @@ def create_app() -> Flask:
     """
     logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
     app = Flask(__name__)
-    game_state = GameState(load_characters())
+    # Load characters once at startup and reuse for resets to avoid external
+    # dependency calls during tests.
+    initial_characters = load_characters()
+    game_state = GameState(list(initial_characters))
     assessor = AssessmentAgent()
+    enable_parallel = os.environ.get("ENABLE_PARALLELISM") == "1"
+    pending_actions: Dict[int, queue.Queue[List[str]]] = {}
+    assessment_threads: List[threading.Thread] = []
+    assessment_lock = threading.Lock()
+    state_lock = threading.Lock()
 
     @app.before_request
     def log_request() -> None:
@@ -46,10 +56,33 @@ def create_app() -> Flask:
             HTML string listing characters and state.
         """
         logger.info("Listing characters")
+        with state_lock:
+            score = game_state.final_weighted_score()
+            hist_snapshot = list(game_state.history)
+            characters = list(game_state.characters)
+            state_html = game_state.render_state()
+        if score >= 80 or len(hist_snapshot) >= 10:
+            return redirect("/result")
+
+        if enable_parallel:
+            pending_actions.clear()
+
+            def launch(idx: int, char) -> None:
+                q: queue.Queue[List[str]] = queue.Queue()
+                pending_actions[idx] = q
+
+                def worker() -> None:
+                    q.put(char.generate_actions(hist_snapshot))
+
+                threading.Thread(target=worker, daemon=True).start()
+
+            for idx, char in enumerate(characters):
+                launch(idx, char)
+
         options = "".join(
             f'<input type="radio" name="character" value="{idx}" id="char{idx}">'\
             f'<label for="char{idx}">{char.name}</label><br>'
-            for idx, char in enumerate(game_state.characters)
+            for idx, char in enumerate(characters)
         )
         return (
             "<form method='post' action='/actions'>"
@@ -59,7 +92,7 @@ def create_app() -> Flask:
             "<form method='post' action='/reset'>"
             "<button type='submit'>Reset</button>"
             "</form>"
-            f"{game_state.render_state()}"
+            f"{state_html}"
         )
 
     @app.route("/actions", methods=["POST"])
@@ -71,8 +104,24 @@ def create_app() -> Flask:
         """
         char_id = int(request.form["character"])
         logger.info("Generating actions for character %d", char_id)
-        char = game_state.characters[char_id]
-        actions: List[str] = char.generate_actions(game_state.history)
+        with state_lock:
+            char = game_state.characters[char_id]
+            hist_snapshot = list(game_state.history)
+            state_html = game_state.render_state()
+        actions: List[str]
+        if enable_parallel:
+            q = pending_actions.get(char_id)
+            if q is not None:
+                if q.empty():
+                    return (
+                        "<p>Loading...</p>"
+                        "<meta http-equiv='refresh' content='1'>"
+                    )
+                actions = q.get()
+            else:
+                actions = char.generate_actions(hist_snapshot)
+        else:
+            actions = char.generate_actions(hist_snapshot)
         logger.debug("Actions: %s", actions)
         radios = "".join(
             f'<input type="radio" name="action" value="{a}" id="a{idx}">'\
@@ -89,7 +138,7 @@ def create_app() -> Flask:
             "<form method='post' action='/reset'>"
             "<button type='submit'>Reset</button>"
             "</form>"
-            f"{game_state.render_state()}"
+            f"{state_html}"
         )
 
     @app.route("/perform", methods=["POST"])
@@ -102,13 +151,51 @@ def create_app() -> Flask:
         char_id = int(request.form["character"])
         action = request.form["action"]
         logger.info("Performing action '%s' for character %d", action, char_id)
-        char = game_state.characters[char_id]
-        game_state.record_action(char, action)
-        scores = assessor.assess(game_state.characters, game_state.how_to_win, game_state.history)
-        logger.debug("Scores: %s", scores)
-        game_state.update_progress(scores)
-        final_score = game_state.final_weighted_score()
-        if final_score >= 80 or len(game_state.history) >= 10:
+        with state_lock:
+            char = game_state.characters[char_id]
+            game_state.record_action(char, action)
+            chars_snapshot = list(game_state.characters)
+            history_snapshot = list(game_state.history)
+            how_to_win = game_state.how_to_win
+
+        if enable_parallel:
+            def run_assessment(chars: List, htw: str, hist: List) -> None:
+                try:
+                    scores = assessor.assess(
+                        chars,
+                        htw,
+                        hist,
+                        parallel=True,
+                    )
+                    with state_lock:
+                        game_state.update_progress(scores)
+                finally:
+                    with assessment_lock:
+                        try:
+                            assessment_threads.remove(threading.current_thread())
+                        except ValueError:
+                            pass
+
+            t = threading.Thread(
+                target=run_assessment,
+                args=(chars_snapshot, how_to_win, history_snapshot),
+                daemon=True,
+            )
+            with assessment_lock:
+                assessment_threads.append(t)
+            t.start()
+        else:
+            scores = assessor.assess(
+                chars_snapshot, how_to_win, history_snapshot
+            )
+            logger.debug("Scores: %s", scores)
+            with state_lock:
+                game_state.update_progress(scores)
+
+        with state_lock:
+            final_score = game_state.final_weighted_score()
+            hist_len = len(game_state.history)
+        if final_score >= 80 or hist_len >= 10:
             return redirect("/result")
         return redirect("/")
 
@@ -116,17 +203,33 @@ def create_app() -> Flask:
     def reset() -> Response:
         """Reset the game to its initial state."""
         nonlocal game_state
-        game_state = GameState(load_characters())
+        with state_lock:
+            # Recreate game state from the initially loaded characters
+            game_state = GameState(list(initial_characters))
+            pending_actions.clear()
+        with assessment_lock:
+            assessment_threads.clear()
         return redirect("/")
 
     @app.route("/result", methods=["GET"])
     def result() -> str:
         """Display the final game outcome."""
-        final = game_state.final_weighted_score()
+        if enable_parallel:
+            with assessment_lock:
+                threads_copy = list(assessment_threads)
+            if any(t.is_alive() for t in threads_copy):
+                return (
+                    "<p>Waiting for assessments...</p>"
+                    "<meta http-equiv='refresh' content='1'>"
+                )
+
+        with state_lock:
+            final = game_state.final_weighted_score()
+            state_html = game_state.render_state()
         outcome = "You won!" if final >= 80 else "You lost!"
         return (
             f"<h1>{outcome}</h1>"
-            f"{game_state.render_state()}"
+            f"{state_html}"
             "<form method='post' action='/reset'>"
             "<button type='submit'>Reset</button>"
             "</form>"


### PR DESCRIPTION
## Summary
- Use thread-local generative model instances so assessments can run concurrently without locking
- Run assessment and action generation in background threads using snapshots with synchronized result aggregation
- Recreate game state from initially loaded characters on reset to avoid extra model setup
- Add unit tests exercising async action generation and background assessment workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1df182ae88333907a0b401627d8ac