### PR TITLE
Add parallel assessment mode and background web actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ character choices as radio buttons. Select a character and submit to see
 possible actions, then choose an action and press **Send** to view the
 character's response.
 
+Set the environment variable `ENABLE_PARALLELISM=1` to run the web
+service with experimental threading support. When enabled the server
+pre-generates character actions and performs progress assessments in the
+background, improving responsiveness.
+
 ### Logging
 
 Both entry points respect the `LOG_LEVEL` environment variable to control

--- a/rpg/assessment_agent.py
+++ b/rpg/assessment_agent.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Tuple
 
 try:  # pragma: no cover - optional dependency
@@ -26,13 +28,65 @@ class AssessmentAgent:
         """
         if genai is None:  # pragma: no cover - environment without dependency
             raise ModuleNotFoundError("google-generativeai not installed")
-        self._model = genai.GenerativeModel(model)
+        # Store the genai module reference so patched versions persist per instance
+        self._genai = genai
+        # keep only the model name and create a per-thread model on demand
+        self._model_name = model
+        self._local = threading.local()
+
+    def _get_model(self):
+        """Return a thread-local GenerativeModel instance."""
+        if not hasattr(self._local, "model"):
+            self._local.model = self._genai.GenerativeModel(self._model_name)
+        return self._local.model
+
+    def _assess_single(
+        self,
+        char: Character,
+        actor_list: str,
+        how_to_win: str,
+        history_text: str,
+    ) -> List[int]:
+        """Assess ``char`` returning a list of progress scores.
+
+        This helper exists so assessments for multiple characters can be
+        executed in parallel using threads when requested by the caller.
+        """
+
+        context = f"{char.base_context}\n{char._triplet_text()}"
+        prompt = (
+            "You are the Game Master for the 'Keep the future human' survival RPG. "
+            "The player is interacting with the characters and convinces them to take actions. "
+            f"You assess of the following character's 'initial state - end state - gap' triplets with a 0-100 integer: {actor_list}, "
+            "based on the baseline script and the performed actions.\n"
+            f"The baseline script: {how_to_win}\n"
+            f"Performed actions: {history_text}\n"
+            f"Assess all triplets of the character {context}.\n"
+            "Output ONLY an ordered list of 0-100 integers one for each triplet line-by-line."
+        )
+        logger.debug("Assessment prompt for %s: %s", char.name, prompt)
+        response = self._get_model().generate_content(prompt)
+        text = getattr(response, "text", "")
+        logger.info("Assessment for %s: %s", char.name, text[:50])
+        scores: List[int] = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            num = ''.join(ch for ch in line if ch.isdigit())
+            if not num:
+                continue
+            scores.append(max(0, min(100, int(num))))
+            if len(scores) == len(char.triplets):
+                break
+        return scores
 
     def assess(
         self,
         characters: List[Character],
         how_to_win: str,
         history: List[Tuple[str, str]],
+        parallel: bool = False,
     ) -> Dict[str, List[int]]:
         """Assess all triplets for each character.
 
@@ -46,33 +100,20 @@ class AssessmentAgent:
         """
         actor_list = ", ".join(c.name for c in characters)
         history_text = "\n".join(f"{actor}: {act}" for actor, act in history) or "None"
+
+        if parallel:
+            with ThreadPoolExecutor(max_workers=len(characters)) as executor:
+                future_map = {
+                    executor.submit(
+                        self._assess_single, char, actor_list, how_to_win, history_text
+                    ): char.name
+                    for char in characters
+                }
+                return {name: fut.result() for fut, name in future_map.items()}
+
         results: Dict[str, List[int]] = {}
         for char in characters:
-            context = f"{char.base_context}\n{char._triplet_text()}"
-            prompt = (
-                "You are the Game Master for the 'Keep the future human' survival RPG. "
-                "The player is interacting with the characters and convinces them to take actions. "
-                f"You assess of the following character's 'initial state - end state - gap' triplets with a 0-100 integer: {actor_list}, "
-                "based on the baseline script and the performed actions.\n"
-                f"The baseline script: {how_to_win}\n"
-                f"Performed actions: {history_text}\n"
-                f"Assess all triplets of the character {context}.\n"
-                "Output ONLY an ordered list of 0-100 integers one for each triplet line-by-line."
+            results[char.name] = self._assess_single(
+                char, actor_list, how_to_win, history_text
             )
-            logger.debug("Assessment prompt for %s: %s", char.name, prompt)
-            response = self._model.generate_content(prompt)
-            text = getattr(response, "text", "")
-            logger.info("Assessment for %s: %s", char.name, text[:50])
-            scores: List[int] = []
-            for line in text.splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                num = ''.join(ch for ch in line if ch.isdigit())
-                if not num:
-                    continue
-                scores.append(max(0, min(100, int(num))))
-                if len(scores) == len(char.triplets):
-                    break
-            results[char.name] = scores
         return results

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,83 @@
+import os
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from web_service import create_app
+from rpg.character import YamlCharacter
+
+FIXTURE_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "characters.yaml")
+
+
+@patch.dict(os.environ, {"ENABLE_PARALLELISM": "1"})
+@patch("rpg.assessment_agent.genai")
+@patch("rpg.character.genai")
+def test_async_action_generation(mock_char_genai, mock_assess_genai):
+    mock_char_genai.GenerativeModel.return_value = MagicMock()
+    mock_assess_genai.GenerativeModel.return_value = MagicMock()
+    with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    character = YamlCharacter("test_character", data["test_character"])
+
+    start_evt = threading.Event()
+    finish_evt = threading.Event()
+
+    def slow_actions(history):
+        start_evt.set()
+        finish_evt.wait()
+        return ["A"]
+
+    with patch.object(character, "generate_actions", side_effect=slow_actions):
+        with patch("web_service.load_characters", return_value=[character]):
+            app = create_app()
+            client = app.test_client()
+            client.get("/")
+            assert start_evt.wait(timeout=1)
+            resp = client.post("/actions", data={"character": "0"})
+            assert b"Loading" in resp.data
+            finish_evt.set()
+            time.sleep(0.1)
+            resp = client.post("/actions", data={"character": "0"})
+            assert b"A" in resp.data
+
+
+@patch.dict(os.environ, {"ENABLE_PARALLELISM": "1"})
+@patch("rpg.assessment_agent.genai")
+@patch("rpg.character.genai")
+def test_assessment_background_wait(mock_char_genai, mock_assess_genai):
+    mock_char_genai.GenerativeModel.return_value = MagicMock()
+    mock_assess_genai.GenerativeModel.return_value = MagicMock()
+    with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    character = YamlCharacter("test_character", data["test_character"])
+
+    start_evt = threading.Event()
+    finish_evt = threading.Event()
+
+    with patch.object(character, "generate_actions", return_value=["A"]):
+        class DummyAssess:
+            def assess(self, chars, htw, hist, parallel=False):
+                start_evt.set()
+                finish_evt.wait()
+                return {c.name: [100] * len(c.triplets) for c in chars}
+
+        with patch("web_service.AssessmentAgent", return_value=DummyAssess()):
+            with patch("web_service.load_characters", return_value=[character]):
+                app = create_app()
+                client = app.test_client()
+                client.get("/")
+                resp = client.post(
+                    "/perform", data={"character": "0", "action": "A"}
+                )
+                assert resp.status_code == 302
+                assert start_evt.wait(timeout=1)
+                resp = client.get("/result")
+                assert b"Waiting for assessments" in resp.data
+                finish_evt.set()
+                time.sleep(0.1)
+                resp = client.get("/result")
+                assert b"You won" in resp.data


### PR DESCRIPTION
## Summary
- document optional parallel web service mode with `ENABLE_PARALLELISM`
- run assessments concurrently using thread-local Gemini models
- add threading support to web service for pre-generating actions and deferred assessments
- add tests covering asynchronous action generation and background assessments

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1f653df0c8333a1325221422d1e60