### PR TITLE
Fix parallel action loading and display title page

### DIFF
--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -41,6 +41,8 @@ def test_async_action_generation(mock_char_genai, mock_assess_genai):
             assert b"Loading" in resp.data
             finish_evt.set()
             time.sleep(0.1)
+            resp = client.get("/actions", query_string={"character": "0"})
+            assert b"A" in resp.data
             resp = client.post("/actions", data={"character": "0"})
             assert b"A" in resp.data
 

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -40,6 +40,7 @@ class WebServiceTest(unittest.TestCase):
         resp = client.get("/")
         page = resp.data.decode()
         self.assertEqual(resp.status_code, 200)
+        self.assertIn("Keep the Future Human Survival RPG", page)
         self.assertIn("Reset", page)
 
         resp = client.post(


### PR DESCRIPTION
## Summary
- show a heading on the character selection page so the title is visible at startup
- allow the action endpoint to refresh via GET and cache generated actions
- extend tests for parallel action loading and for the title page

## Testing
- `pytest tests/test_character.py tests/test_parallel.py tests/test_web_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68c26fd345748333b3c97c9e35f9a190