### PR TITLE
Expose instructions page and improve history rendering

### DIFF
--- a/rpg/character.py
+++ b/rpg/character.py
@@ -149,7 +149,7 @@ class YamlCharacter(Character):
         logger.debug("Prompt: %s", prompt)
         response = self._model.generate_content(prompt)
         response_text = getattr(response, "text", "")
-        logger.info("Generated: %s", response_text[:50])
+        logger.info("Generated for %s: %s", self.name, response_text[:50])
         logger.debug("Response: %s", response_text)
         lines = [line.strip() for line in response_text.splitlines() if line.strip()]
         actions: List[str] = []

--- a/rpg/game_state.py
+++ b/rpg/game_state.py
@@ -101,7 +101,9 @@ class GameState:
             for name, scores in self.progress.items()
         ]
         if self.history:
-            lines.append("<h2>Action History</h2>")
-            lines.extend(f"{n}: {a}" for n, a in self.history)
+            hist_items = "".join(
+                f"<li><strong>{n}</strong>: {a}</li>" for n, a in self.history
+            )
+            lines.append(f"<h2>Action History</h2><ol>{hist_items}</ol>")
         lines.append(f"Final weighted score: {self.final_weighted_score()}")
         return "<div id='state'>" + "<br>".join(lines) + "</div>"

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -42,6 +42,14 @@ class WebServiceTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Keep the Future Human Survival RPG", page)
         self.assertIn("Reset", page)
+        self.assertIn("Instructions", page)
+        self.assertIn("GitHub", page)
+
+        inst_resp = client.get("/instructions")
+        inst_page = inst_resp.data.decode()
+        self.assertEqual(inst_resp.status_code, 200)
+        self.assertIn("Instructions", inst_page)
+        self.assertIn("GitHub", inst_page)
 
         resp = client.post(
             "/perform", data={"character": "0", "action": "A"}, follow_redirects=True
@@ -51,15 +59,17 @@ class WebServiceTest(unittest.TestCase):
         self.assertEqual(resp.request.path, "/result")
         self.assertIn("You won!", page)
         self.assertIn("Action History", page)
-        self.assertIn("test_character: A", page)
+        self.assertIn("<li><strong>test_character</strong>: A</li>", page)
         self.assertIn("Final weighted score", page)
         self.assertIn("Reset", page)
+        self.assertIn("GitHub", page)
 
         resp = client.post("/reset", follow_redirects=True)
         page = resp.data.decode()
         self.assertEqual(resp.request.path, "/")
         self.assertIn("Final weighted score: 0", page)
         self.assertNotIn("Action History", page)
+        self.assertIn("GitHub", page)
 
     def test_loss_after_ten_actions(self):
         with patch("rpg.character.genai") as mock_char_genai, patch(
@@ -97,6 +107,7 @@ class WebServiceTest(unittest.TestCase):
         self.assertIn("Action History", page)
         self.assertIn("Final weighted score", page)
         self.assertIn("Reset", page)
+        self.assertIn("GitHub", page)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log generated action text with actor names for clearer debugging
- render action history as a numbered list with bold actor names
- add instructions page and GitHub link footer across views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2a1675be08333bb4db76471c71de1