### PR TITLE
Add landing page with start link and fix GitHub URL

### DIFF
--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -35,7 +35,7 @@ def test_async_action_generation(mock_char_genai, mock_assess_genai):
         with patch("web_service.load_characters", return_value=[character]):
             app = create_app()
             client = app.test_client()
-            client.get("/")
+            client.get("/start")
             assert start_evt.wait(timeout=1)
             resp = client.post("/actions", data={"character": "0"})
             assert b"Loading" in resp.data
@@ -71,7 +71,7 @@ def test_assessment_background_wait(mock_char_genai, mock_assess_genai):
             with patch("web_service.load_characters", return_value=[character]):
                 app = create_app()
                 client = app.test_client()
-                client.get("/")
+                client.get("/start")
                 resp = client.post(
                     "/perform", data={"character": "0", "action": "A"}
                 )

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -40,10 +40,18 @@ class WebServiceTest(unittest.TestCase):
         resp = client.get("/")
         page = resp.data.decode()
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Keep the Future Human Survival RPG", page)
-        self.assertIn("Reset", page)
+        self.assertIn("AI Safety Negotiation Game", page)
+        self.assertIn("Start", page)
         self.assertIn("Instructions", page)
         self.assertIn("GitHub", page)
+
+        start_resp = client.get("/start")
+        start_page = start_resp.data.decode()
+        self.assertEqual(start_resp.status_code, 200)
+        self.assertIn("Keep the Future Human Survival RPG", start_page)
+        self.assertIn("Reset", start_page)
+        self.assertIn("Instructions", start_page)
+        self.assertIn("GitHub", start_page)
 
         inst_resp = client.get("/instructions")
         inst_page = inst_resp.data.decode()
@@ -66,7 +74,7 @@ class WebServiceTest(unittest.TestCase):
 
         resp = client.post("/reset", follow_redirects=True)
         page = resp.data.decode()
-        self.assertEqual(resp.request.path, "/")
+        self.assertEqual(resp.request.path, "/start")
         self.assertIn("Final weighted score: 0", page)
         self.assertNotIn("Action History", page)
         self.assertIn("GitHub", page)
@@ -96,7 +104,7 @@ class WebServiceTest(unittest.TestCase):
             resp = client.post(
                 "/perform", data={"character": "0", "action": "A"}, follow_redirects=True
             )
-            self.assertEqual(resp.request.path, "/")
+            self.assertEqual(resp.request.path, "/start")
 
         resp = client.post(
             "/perform", data={"character": "0", "action": "A"}, follow_redirects=True

--- a/web_service.py
+++ b/web_service.py
@@ -16,7 +16,7 @@ from cli_game import load_characters
 from rpg.game_state import GameState
 from rpg.assessment_agent import AssessmentAgent
 
-GITHUB_URL = "https://github.com/keep-the-future-human/keep-the-future-human-survival-rpg"
+GITHUB_URL = "https://github.com/keep-the-future-human/ai-safety-negotiation-game"
 
 
 logger = logging.getLogger(__name__)
@@ -55,12 +55,19 @@ def create_app() -> Flask:
         logger.info("%s %s", request.method, request.path)
 
     @app.route("/", methods=["GET"])
-    def list_characters() -> str:
-        """Display available characters and current game state.
+    def main_page() -> str:
+        """Display the landing page with game introduction."""
+        return (
+            "<h1>AI Safety Negotiation Game</h1>"
+            "<p>You are an expert negotiator with connection to all relevant actors in the AI safety world, you can convince them to propose and take actions.  your objective is to enure that ai is developed in the best interest of humanity. your goal is to keep the future human.</p>"
+            "<p>You have 10 turns to reach a final weighted score of 80 or higher to win.</p>"
+            "<a href='/start'>Start</a>"
+            f"{footer}"
+        )
 
-        Returns:
-            HTML string listing characters and state.
-        """
+    @app.route("/start", methods=["GET"])
+    def list_characters() -> str:
+        """Display available characters and current game state."""
         logger.info("Listing characters")
         with state_lock:
             score = game_state.final_weighted_score()
@@ -145,7 +152,7 @@ def create_app() -> Flask:
             f"<input type='hidden' name='character' value='{char_id}'>"
             "<button type='submit'>Send</button>"
             "</form>"
-            "<a href='/'>Back to characters</a>"
+            "<a href='/start'>Back to characters</a>"
             "<form method='post' action='/reset'>"
             "<button type='submit'>Reset</button>"
             "</form>"
@@ -155,10 +162,10 @@ def create_app() -> Flask:
 
     @app.route("/perform", methods=["POST"])
     def character_perform() -> Response:
-        """Carry out a character action and redirect to the main page.
+        """Carry out a character action and redirect to the start page.
 
         Returns:
-            A redirect response to the root page.
+            A redirect response to the start page.
         """
         char_id = int(request.form["character"])
         action = request.form["action"]
@@ -210,7 +217,7 @@ def create_app() -> Flask:
             hist_len = len(game_state.history)
         if final_score >= 80 or hist_len >= 10:
             return redirect("/result")
-        return redirect("/")
+        return redirect("/start")
 
     @app.route("/reset", methods=["POST"])
     def reset() -> Response:
@@ -222,7 +229,7 @@ def create_app() -> Flask:
             pending_actions.clear()
         with assessment_lock:
             assessment_threads.clear()
-        return redirect("/")
+        return redirect("/start")
 
     @app.route("/instructions", methods=["GET"])
     def instructions() -> str:
@@ -232,7 +239,7 @@ def create_app() -> Flask:
         return (
             "<h1>Instructions</h1>"
             f"<pre>{content}</pre>"
-            "<a href='/'>Back to game</a>"
+            "<a href='/start'>Back to game</a>"
             f"{footer}"
         )
 


### PR DESCRIPTION
## Summary
- Add introduction landing page at `/` for AI Safety Negotiation Game with start link
- Move character selection to `/start` and keep footer links
- Update GitHub footer URL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c32902eab88333b991d6fba6965df3