### PR TITLE
feat: show character action prompt

### DIFF
--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -53,6 +53,14 @@ class WebServiceTest(unittest.TestCase):
         self.assertIn("Instructions", start_page)
         self.assertIn("GitHub", start_page)
 
+        actions_resp = client.post("/actions", data={"character": "0"})
+        actions_page = actions_resp.data.decode()
+        self.assertEqual(actions_resp.status_code, 200)
+        self.assertIn("<h1>test_character</h1>", actions_page)
+        self.assertIn(
+            "Which action do you want test_character to perform?", actions_page
+        )
+
         inst_resp = client.get("/instructions")
         inst_page = inst_resp.data.decode()
         self.assertEqual(inst_resp.status_code, 200)

--- a/web_service.py
+++ b/web_service.py
@@ -16,7 +16,8 @@ from cli_game import load_characters
 from rpg.game_state import GameState
 from rpg.assessment_agent import AssessmentAgent
 
-GITHUB_URL = "https://github.com/keep-the-future-human/ai-safety-negotiation-game"
+# Link to this project's source code repository for inclusion in the web UI footer
+GITHUB_URL = "https://github.com/balazsbme/keep-the-future-human-survival-rpg"
 
 
 logger = logging.getLogger(__name__)
@@ -147,6 +148,8 @@ def create_app() -> Flask:
             for idx, a in enumerate(actions)
         )
         return (
+            f"<h1>{char.name}</h1>"
+            f"<p>Which action do you want {char.name} to perform?</p>"
             "<form method='post' action='/perform'>"
             f"{radios}"
             f"<input type='hidden' name='character' value='{char_id}'>"


### PR DESCRIPTION
## Summary
- link web UI footer to this repository
- display selected character name and prompt on action selection screen

## Testing
- `pytest tests/test_character.py -q`
- `pytest tests/test_parallel.py -q`
- `pytest tests/test_web_service.py -q`
- `pytest tests/test_genai_example.py -q` *(skipped: took 600s)*

------
https://chatgpt.com/codex/tasks/task_e_68c33a172dfc83339a84b12506791c1c