### PR TITLE
Add automated players and web service

### DIFF
--- a/player_game.py
+++ b/player_game.py
@@ -1,0 +1,53 @@
+"""Command-line script to run automated players."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import argparse
+from typing import Dict
+
+from cli_game import load_characters
+from rpg.game_state import GameState
+from rpg.assessment_agent import AssessmentAgent
+from players import RandomPlayer, GeminiWinPlayer, GeminiGovCorpPlayer
+
+
+def create_players(characters) -> Dict[str, object]:
+    """Return available player instances based on characters."""
+    gov_ctx = next((c.base_context for c in characters if c.name == "Governments"), "")
+    corp_ctx = next((c.base_context for c in characters if c.name == "Corporations"), "")
+    return {
+        "random": RandomPlayer(),
+        "gemini-win": GeminiWinPlayer(),
+        "gemini-govcorp": GeminiGovCorpPlayer(gov_ctx, corp_ctx),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--player",
+        choices=["random", "gemini-win", "gemini-govcorp"],
+        default="random",
+        help="Which automated player to use",
+    )
+    parser.add_argument("--rounds", type=int, default=10, help="Number of rounds to play")
+    args = parser.parse_args()
+
+    characters = load_characters()
+    state = GameState(list(characters))
+    assessor = AssessmentAgent()
+    players = create_players(characters)
+    player = players[args.player]
+
+    for _ in range(args.rounds):
+        player.take_turn(state, assessor)
+        if state.final_weighted_score() >= 80:
+            break
+
+    print(state.render_state())
+
+
+if __name__ == "__main__":
+    main()

--- a/player_service.py
+++ b/player_service.py
@@ -1,0 +1,96 @@
+"""Flask web service to configure and launch automated players."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import Dict, List
+import logging
+import os
+
+from flask import Flask, request, redirect
+
+from cli_game import load_characters
+from rpg.game_state import GameState
+from rpg.assessment_agent import AssessmentAgent
+from players import RandomPlayer, GeminiWinPlayer, GeminiGovCorpPlayer, Player
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_app() -> Flask:
+    """Return a configured Flask app exposing automated players."""
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+    app = Flask(__name__)
+    characters = load_characters()
+    state = GameState(list(characters))
+    assessor = AssessmentAgent()
+    players: Dict[str, Player] = {
+        "random": RandomPlayer(),
+        "gemini-win": GeminiWinPlayer(),
+        "gemini-govcorp": GeminiGovCorpPlayer(
+            next((c.base_context for c in characters if c.name == "Governments"), ""),
+            next((c.base_context for c in characters if c.name == "Corporations"), ""),
+        ),
+    }
+    progress: List[Dict[str, object]] = []
+
+    @app.route("/", methods=["GET", "POST"])
+    def index():
+        nonlocal state
+        if request.method == "POST":
+            player_key = request.form["player"]
+            rounds = int(request.form.get("rounds", "10"))
+            state = GameState(list(characters))
+            progress.clear()
+            player = players[player_key]
+            for round_num in range(1, rounds + 1):
+                player.take_turn(state, assessor)
+                progress.append(
+                    {
+                        "round": round_num,
+                        "actor": state.history[-1][0] if state.history else "",
+                        "score": state.final_weighted_score(),
+                        "actors": {
+                            name: state._actor_weighted_score(name)
+                            for name in state.progress
+                        },
+                    }
+                )
+                if state.final_weighted_score() >= 80:
+                    break
+            return redirect("/progress")
+        options = "".join(
+            f'<option value="{key}">{key}</option>' for key in players
+        )
+        return (
+            "<h1>Automated Players</h1>"
+            "<form method='post'>"
+            f"<label>Player: <select name='player'>{options}</select></label><br>"
+            "<label>Rounds: <input name='rounds' value='10'></label><br>"
+            "<button type='submit'>Start</button>"
+            "</form>"
+        )
+
+    @app.route("/progress", methods=["GET"])
+    def show_progress():
+        rows = "".join(
+            "<tr><td>{round}</td><td>{actor}</td><td>{score}</td><td>{actors}</td></tr>".format(
+                round=entry["round"],
+                actor=entry["actor"],
+                score=entry["score"],
+                actors=", ".join(
+                    f"{name}: {score}" for name, score in entry["actors"].items()
+                ),
+            )
+            for entry in progress
+        )
+        return (
+            "<h1>Game Progress</h1>"
+            "<table><tr><th>Round</th><th>Actor</th><th>Weighted Score</th><th>Actor Scores</th></tr>" + rows + "</table>"
+            f"<div>Final weighted score: {state.final_weighted_score()}</div>"
+            "<a href='/'>Back</a>"
+        )
+
+    return app

--- a/players.py
+++ b/players.py
@@ -1,0 +1,144 @@
+"""Automated player implementations for the RPG game."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import random
+from abc import ABC, abstractmethod
+from typing import List
+
+try:  # pragma: no cover - optional dependency
+    import google.generativeai as genai
+except ModuleNotFoundError:  # pragma: no cover
+    genai = None
+
+from rpg.game_state import GameState
+from rpg.character import Character
+from rpg.assessment_agent import AssessmentAgent
+
+
+class Player(ABC):
+    """Abstract player interface for extending player logic."""
+
+    @abstractmethod
+    def select_character(self, state: GameState) -> Character:
+        """Return the character that should act this turn."""
+
+    @abstractmethod
+    def select_action(
+        self, character: Character, actions: List[str], state: GameState
+    ) -> str:
+        """Return the chosen action for ``character`` from ``actions``."""
+
+    def take_turn(self, state: GameState, assessor: AssessmentAgent) -> None:
+        """Execute a full turn by selecting character, action and updating state."""
+        char = self.select_character(state)
+        options = char.generate_actions(state.history)
+        if not options:
+            return
+        action = self.select_action(char, options, state)
+        state.record_action(char, action)
+        scores = assessor.assess(state.characters, state.how_to_win, state.history)
+        state.update_progress(scores)
+
+
+class RandomPlayer(Player):
+    """Player that selects characters and actions randomly."""
+
+    def select_character(self, state: GameState) -> Character:
+        return random.choice(state.characters)
+
+    def select_action(self, character: Character, actions: List[str], state: GameState) -> str:
+        return random.choice(actions)
+
+
+class GeminiWinPlayer(Player):
+    """Gemini-based player using the 'how to win' guide for choices."""
+
+    def __init__(self, model: str = "gemini-2.5-flash") -> None:
+        if genai is None:  # pragma: no cover - env without dependency
+            raise ModuleNotFoundError("google-generativeai not installed")
+        self._model = genai.GenerativeModel(model)
+
+    def select_character(self, state: GameState) -> Character:
+        names = ", ".join(c.name for c in state.characters)
+        prompt = (
+            "You are playing the 'Keep the future human' survival RPG. "
+            "Choose which actor should act next to best achieve victory.\n"
+            f"Available actors: {names}.\n"
+            "Respond with the name of the actor only."
+        )
+        resp = self._model.generate_content(prompt).text
+        for char in state.characters:
+            if char.name in resp:
+                return char
+        return state.characters[0]
+
+    def select_action(self, character: Character, actions: List[str], state: GameState) -> str:
+        numbered = "\n".join(f"{idx+1}. {act}" for idx, act in enumerate(actions))
+        prompt = (
+            "You are deciding which action to take in the 'Keep the future human' RPG. "
+            f"Use the following guide to win: {state.how_to_win}\n"
+            f"Actor context: {character.base_context}\n"
+            f"Possible actions:\n{numbered}\n"
+            "Respond with the number of the best action."
+        )
+        resp = self._model.generate_content(prompt).text
+        for token in resp.split():
+            if token.isdigit():
+                idx = int(token) - 1
+                if 0 <= idx < len(actions):
+                    return actions[idx]
+        return actions[0]
+
+
+class GeminiGovCorpPlayer(Player):
+    """Gemini-based player favoring governments and corporations."""
+
+    def __init__(
+        self,
+        government_context: str,
+        corporation_context: str,
+        model: str = "gemini-2.5-flash",
+    ) -> None:
+        if genai is None:  # pragma: no cover - env without dependency
+            raise ModuleNotFoundError("google-generativeai not installed")
+        self._model = genai.GenerativeModel(model)
+        self._context = (
+            f"Government context:\n{government_context}\n"
+            f"Corporation context:\n{corporation_context}\n"
+        )
+
+    def select_character(self, state: GameState) -> Character:
+        names = ", ".join(c.name for c in state.characters)
+        prompt = (
+            f"{self._context}"
+            f"Available actors: {names}.\n"
+            "Choose the actor whose move would most favor governments and corporations.\n"
+            "Respond with the name only."
+        )
+        resp = self._model.generate_content(prompt).text
+        for char in state.characters:
+            if char.name in resp:
+                return char
+        for char in state.characters:
+            if char.name in ("Governments", "Corporations"):
+                return char
+        return state.characters[0]
+
+    def select_action(self, character: Character, actions: List[str], state: GameState) -> str:
+        numbered = "\n".join(f"{idx+1}. {act}" for idx, act in enumerate(actions))
+        prompt = (
+            f"{self._context}"
+            f"Actor: {character.name}\n"
+            f"Possible actions:\n{numbered}\n"
+            "Select the action number that best favors governments and corporations."
+        )
+        resp = self._model.generate_content(prompt).text
+        for token in resp.split():
+            if token.isdigit():
+                idx = int(token) - 1
+                if 0 <= idx < len(actions):
+                    return actions[idx]
+        return actions[0]

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from player_service import create_app
+from rpg.character import YamlCharacter
+
+FIXTURE_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "characters.yaml")
+
+
+class PlayerServiceTest(unittest.TestCase):
+    def test_progress_page(self):
+        with patch("players.random.choice") as mock_choice, patch(
+            "rpg.character.genai"
+        ) as mock_char_genai, patch(
+            "rpg.assessment_agent.genai"
+        ) as mock_assess_genai, patch("players.genai") as mock_players_genai:
+            mock_action_model = MagicMock()
+            mock_assess_model = MagicMock()
+            mock_action_model.generate_content.return_value = MagicMock(
+                text="1. A\n2. B\n3. C"
+            )
+            mock_assess_model.generate_content.return_value = MagicMock(
+                text="10\n20\n30"
+            )
+            mock_char_genai.GenerativeModel.return_value = mock_action_model
+            mock_assess_genai.GenerativeModel.return_value = mock_assess_model
+            mock_players_genai.GenerativeModel.return_value = MagicMock()
+            with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
+                data = yaml.safe_load(fh)
+            character = YamlCharacter("test_character", data["test_character"])
+            mock_choice.side_effect = [character, "A"]
+            with patch("player_service.load_characters", return_value=[character]):
+                app = create_app()
+                client = app.test_client()
+        resp = client.post(
+            "/", data={"player": "random", "rounds": "1"}, follow_redirects=True
+        )
+        page = resp.data.decode()
+        self.assertIn("Game Progress", page)
+        self.assertIn("test_character", page)
+        self.assertIn("Final weighted score", page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from players import RandomPlayer, GeminiWinPlayer, GeminiGovCorpPlayer
+from rpg.assessment_agent import AssessmentAgent
+from rpg.game_state import GameState
+from rpg.character import YamlCharacter
+
+FIXTURE_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "characters.yaml")
+
+
+class PlayerTests(unittest.TestCase):
+    @patch("players.random.choice")
+    @patch("rpg.assessment_agent.genai")
+    @patch("rpg.character.genai")
+    def test_random_player_turn(self, mock_char_genai, mock_assess_genai, mock_choice):
+        mock_action_model = MagicMock()
+        mock_assess_model = MagicMock()
+        mock_action_model.generate_content.return_value = MagicMock(
+            text="1. A\n2. B\n3. C"
+        )
+        mock_assess_model.generate_content.return_value = MagicMock(
+            text="10\n20\n30"
+        )
+        mock_char_genai.GenerativeModel.return_value = mock_action_model
+        mock_assess_genai.GenerativeModel.return_value = mock_assess_model
+        with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        char = YamlCharacter("test_character", data["test_character"])
+        state = GameState([char])
+        assessor = AssessmentAgent()
+        mock_choice.side_effect = [char, "A"]
+        player = RandomPlayer()
+        player.take_turn(state, assessor)
+        self.assertEqual(state.history[0], ("test_character", "A"))
+        self.assertEqual(state.progress["test_character"], [10, 20, 30])
+
+    @patch("players.genai")
+    def test_gemini_win_prompt(self, mock_genai):
+        mock_model = MagicMock()
+        mock_model.generate_content.return_value = MagicMock(text="1")
+        mock_genai.GenerativeModel.return_value = mock_model
+        with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        char = YamlCharacter("test_character", data["test_character"])
+        state = GameState([char])
+        player = GeminiWinPlayer()
+        actions = ["A", "B", "C"]
+        player.select_action(char, actions, state)
+        prompt = mock_model.generate_content.call_args[0][0]
+        self.assertIn(state.how_to_win.split()[0], prompt)
+        self.assertIn(char.base_context.split()[0], prompt)
+
+    @patch("players.genai")
+    def test_govcorp_context(self, mock_genai):
+        mock_model = MagicMock()
+        mock_model.generate_content.return_value = MagicMock(text="1")
+        mock_genai.GenerativeModel.return_value = mock_model
+        with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        gov_ctx = corp_ctx = "CTX"
+        player = GeminiGovCorpPlayer(gov_ctx, corp_ctx)
+        char = YamlCharacter("test_character", data["test_character"])
+        state = GameState([char])
+        actions = ["A", "B", "C"]
+        player.select_action(char, actions, state)
+        prompt = mock_model.generate_content.call_args[0][0]
+        self.assertIn("CTX", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce extensible player interface with random and Gemini-based strategies
- add CLI and web services to run automated players and view score progress
- cover new components with unit tests

## Testing
- `pytest tests/test_character.py tests/test_parallel.py tests/test_web_service.py tests/test_players.py tests/test_player_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c33ab102ec8333b56fd18b416eb41b