### PR TITLE
Add entry point for player service app

### DIFF
--- a/player_service.py
+++ b/player_service.py
@@ -94,3 +94,8 @@ def create_app() -> Flask:
         )
 
     return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 7860)))


### PR DESCRIPTION
## Summary
- Add a `__main__` section so running `player_service.py` launches the Flask app

## Testing
- `pytest -k 'not genai_example'`
- `pytest` *(hangs on `test_genai_example.py`, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c48bc1c6348333a323a0fd0fcde802