### PR TITLE
Add player manager and enhance progress tracking

### DIFF
--- a/player_manager.py
+++ b/player_manager.py
@@ -1,0 +1,156 @@
+"""Manage running automated players across multiple sequential games."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, Iterable, List
+from uuid import uuid4
+
+from rpg.assessment_agent import AssessmentAgent
+from rpg.game_state import GameState
+from players import Player
+
+
+logger = logging.getLogger(__name__)
+
+
+class PlayerManager:
+    """Coordinate launching automated players for multiple games in sequence."""
+
+    def __init__(
+        self,
+        characters: Iterable,
+        assessor: AssessmentAgent,
+        log_dir: str,
+    ) -> None:
+        """Store the characters, assessor, and logging directory for runs."""
+
+        self._characters = list(characters)
+        self._assessor = assessor
+        self._log_dir = log_dir
+        os.makedirs(log_dir, exist_ok=True)
+
+    def run_sequence(
+        self,
+        player_key: str,
+        player: Player,
+        games: int,
+        rounds: int,
+    ) -> List[Dict[str, object]]:
+        """Execute ``games`` sequential games with ``player``.
+
+        Args:
+            player_key: Identifier of the selected player for logging purposes.
+            player: Player implementation to run.
+            games: Number of games to execute sequentially.
+            rounds: Maximum number of rounds per game.
+
+        Returns:
+            List of per-game progress dictionaries suitable for rendering.
+        """
+
+        results: List[Dict[str, object]] = []
+        total_games = max(1, games)
+        max_rounds = max(1, rounds)
+        for game_index in range(1, total_games + 1):
+            logger.info(
+                "Launching game %d/%d for player %s", game_index, total_games, player_key
+            )
+            results.append(
+                self._run_single_game(player_key, player, max_rounds, game_index)
+            )
+        return results
+
+    def _run_single_game(
+        self,
+        player_key: str,
+        player: Player,
+        rounds: int,
+        game_index: int,
+    ) -> Dict[str, object]:
+        """Execute a single game and capture detailed progress information."""
+
+        state = GameState(list(self._characters))
+        log_filename = self._log_filename(player_key, game_index)
+        log_path = os.path.join(self._log_dir, log_filename)
+        file_handler = logging.FileHandler(log_path, mode="w", encoding="utf-8")
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s %(name)s %(levelname)s: %(message)s")
+        )
+        root_logger = logging.getLogger()
+        previous_level = root_logger.level
+        root_logger.addHandler(file_handler)
+        root_logger.setLevel(logging.DEBUG)
+
+        rounds_progress: List[Dict[str, object]] = []
+        try:
+            for round_index in range(1, rounds + 1):
+                logger.info("Beginning round %d", round_index)
+                player.take_turn(state, self._assessor)
+                actor = state.history[-1][0] if state.history else ""
+                final_score = state.final_weighted_score()
+                actor_scores = {
+                    name: {
+                        "scores": list(scores),
+                        "weighted": state._actor_weighted_score(name),
+                    }
+                    for name, scores in state.progress.items()
+                }
+                rounds_progress.append(
+                    {
+                        "round": round_index,
+                        "actor": actor,
+                        "score": final_score,
+                        "actors": actor_scores,
+                    }
+                )
+                logger.info(
+                    "Round %d result: actor=%s score=%s", round_index, actor, final_score
+                )
+                if final_score >= 80:
+                    logger.info(
+                        "Final score threshold reached for game %d; ending early", game_index
+                    )
+                    break
+        finally:
+            root_logger.removeHandler(file_handler)
+            root_logger.setLevel(previous_level)
+            file_handler.close()
+
+        final_score = state.final_weighted_score()
+        game_result = {
+            "game_number": game_index,
+            "rounds": rounds_progress,
+            "final_score": final_score,
+            "result": "Win" if final_score >= 80 else "Lose",
+            "iterations": len(rounds_progress),
+            "actions": len(state.history),
+            "log_filename": log_filename,
+            "final_actors": {
+                name: {
+                    "scores": list(scores),
+                    "weighted": state._actor_weighted_score(name),
+                }
+                for name, scores in state.progress.items()
+            },
+        }
+        logger.info(
+            "Game %d finished with final score %s; log saved to %s",
+            game_index,
+            final_score,
+            log_filename,
+        )
+        return game_result
+
+    def _log_filename(self, player_key: str, game_index: int) -> str:
+        """Return a unique log filename for a specific game run."""
+
+        unique_id = uuid4().hex
+        return f"{player_key}_game_{game_index}_{unique_id}.log"
+
+
+__all__ = ["PlayerManager"]

--- a/player_service.py
+++ b/player_service.py
@@ -4,29 +4,29 @@
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, Set
 import logging
 import os
 
-from flask import Flask, request, redirect
+from flask import Flask, abort, redirect, request, send_from_directory
 
 from cli_game import load_characters
-from rpg.game_state import GameState
-from rpg.assessment_agent import AssessmentAgent
-from players import RandomPlayer, GeminiWinPlayer, GeminiGovCorpPlayer, Player
 from evaluations.assessment_baseline import run_baseline_assessment
 from evaluations.assessment_consistency import run_consistency_assessment
+from player_manager import PlayerManager
+from players import GeminiGovCorpPlayer, GeminiWinPlayer, RandomPlayer
+from rpg.assessment_agent import AssessmentAgent
 
 
 logger = logging.getLogger(__name__)
 
 
-def create_app() -> Flask:
+def create_app(log_dir: str | None = None) -> Flask:
     """Return a configured Flask app exposing automated players."""
+
     logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
     app = Flask(__name__)
     characters = load_characters()
-    state = GameState(list(characters))
     assessor = AssessmentAgent()
     players: Dict[str, Player] = {
         "random": RandomPlayer(),
@@ -36,57 +36,53 @@ def create_app() -> Flask:
             next((c.base_context for c in characters if c.name == "Corporations"), ""),
         ),
     }
-    progress: List[Dict[str, object]] = []
+    if log_dir is None:
+        os.makedirs(app.instance_path, exist_ok=True)
+        log_dir = os.path.join(app.instance_path, "player_logs")
+    os.makedirs(log_dir, exist_ok=True)
+    app.config["PLAYER_LOG_DIR"] = log_dir
+    manager = PlayerManager(characters, assessor, log_dir)
+    game_runs: List[Dict[str, object]] = []
+    known_logs: Set[str] = set()
+    last_run: Dict[str, object] = {}
 
     @app.route("/", methods=["GET", "POST"])
     def index():
-        nonlocal state
+        nonlocal game_runs, known_logs, last_run
         if request.method == "POST":
             player_key = request.form["player"]
-            rounds = int(request.form.get("rounds", "10"))
-            logger.info("Starting new game with player %s for %d rounds", player_key, rounds)
-            state = GameState(list(characters))
-            progress.clear()
-            player = players[player_key]
-            for round_num in range(1, rounds + 1):
-                logger.info("Beginning round %d", round_num)
-                player.take_turn(state, assessor)
-                progress.append(
-                    {
-                        "round": round_num,
-                        "actor": state.history[-1][0] if state.history else "",
-                        "score": state.final_weighted_score(),
-                        "actors": {
-                            name: state._actor_weighted_score(name)
-                            for name in state.progress
-                        },
-                    }
-                )
-                logger.info(
-                    "Round %d result: actor=%s score=%s",
-                    round_num,
-                    progress[-1]["actor"],
-                    progress[-1]["score"],
-                )
-                if state.final_weighted_score() >= 80:
-                    logger.info("Final score threshold reached; ending game")
-                    break
+            try:
+                rounds = int(request.form.get("rounds", "10"))
+            except ValueError:
+                rounds = 10
+            try:
+                games = int(request.form.get("games", "1"))
+            except ValueError:
+                games = 1
+            rounds = max(1, rounds)
+            games = max(1, games)
             logger.info(
-                "Game finished after %d rounds with final score %s",
-                len(progress),
-                state.final_weighted_score(),
+                "Starting sequence for player %s: %d games with %d rounds each",
+                player_key,
+                games,
+                rounds,
             )
+            player = players[player_key]
+            game_runs = manager.run_sequence(player_key, player, games, rounds)
+            known_logs = {entry["log_filename"] for entry in game_runs}
+            last_run = {"player": player_key, "rounds": rounds, "games": games}
             return redirect("/progress")
         logger.info("Showing main player selection page")
         options = "".join(
             f'<option value="{key}">{key}</option>' for key in players
         )
         return (
-            "<h1>Automated Players</h1>"
+            "<h1>Automated Player Manager</h1>"
             "<form method='post'>"
             f"<label>Player: <select name='player'>{options}</select></label><br>"
-            "<label>Rounds: <input name='rounds' value='10'></label><br>"
-            "<button type='submit'>Start</button>"
+            "<label>Games: <input type='number' min='1' name='games' value='1'></label><br>"
+            "<label>Rounds per game: <input type='number' min='1' name='rounds' value='10'></label><br>"
+            "<button type='submit'>Run Sequence</button>"
             "</form>"
             "<h2>Evaluations</h2>"
             "<form action='/evaluation/baseline' method='post'><button type='submit'>Baseline Assessment</button></form>"
@@ -96,35 +92,65 @@ def create_app() -> Flask:
     @app.route("/progress", methods=["GET"])
     def show_progress():
         logger.info("Showing progress page")
-        rows = "".join(
-            "<tr><td>{round}</td><td>{actor}</td><td>{score}</td><td>{actors}</td></tr>".format(
-                round=entry["round"],
-                actor=entry["actor"],
-                score=entry["score"],
-                actors=", ".join(
-                    f"{name}: {score}" for name, score in entry["actors"].items()
-                ),
-            )
-            for entry in progress
-        )
-        final_score = state.final_weighted_score()
-        result = "Win" if final_score >= 80 else "Lose"
+        if not game_runs:
+            return "<h1>No games have been run yet.</h1><a href='/'>Back</a>"
         summary = (
-            "<h1>Game Status</h1>"
-            f"<div>Iterations: {len(progress)}</div>"
-            f"<div>Actions: {len(state.history)}</div>"
-            f"<div>Current weighted final score: {final_score}</div>"
-            f"<div>Result: {result}</div>"
-            "<h2>Game Progress</h2>"
+            "<h1>Player Manager Progress</h1>"
+            f"<div>Selected player: {last_run.get('player', '')}</div>"
+            f"<div>Games requested: {last_run.get('games', 0)}</div>"
+            f"<div>Rounds per game: {last_run.get('rounds', 0)}</div>"
         )
-        return (
-            summary
-            + "<table><tr><th>Round</th><th>Actor</th><th>Weighted Score</th><th>Actor Scores</th></tr>"
-            + rows
-            + "</table>"
-            + f"<div>Final weighted score: {final_score}</div>"
-            + "<a href='/'>Back</a>"
-        )
+
+        def actor_score_lines(actor_data: Dict[str, Dict[str, object]]) -> str:
+            return "<br>".join(
+                "{}: {} (weighted {})".format(
+                    name,
+                    ", ".join(str(score) for score in details["scores"]),
+                    details["weighted"],
+                )
+                for name, details in actor_data.items()
+            )
+
+        sections = []
+        for entry in game_runs:
+            rows = "".join(
+                "<tr><td>{round}</td><td>{actor}</td><td>{score}</td><td>{actors}</td></tr>".format(
+                    round=round_info["round"],
+                    actor=round_info["actor"],
+                    score=round_info["score"],
+                    actors=actor_score_lines(round_info["actors"]),
+                )
+                for round_info in entry["rounds"]
+            )
+            final_actors = actor_score_lines(entry["final_actors"])
+            sections.append(
+                (
+                    f"<section><h2>Game {entry['game_number']}</h2>"
+                    f"<div>Iterations: {entry['iterations']}</div>"
+                    f"<div>Actions: {entry['actions']}</div>"
+                    f"<div>Final weighted score: {entry['final_score']}</div>"
+                    f"<div>Result: {entry['result']}</div>"
+                    f"<div>Final actor scores:<br>{final_actors}</div>"
+                    f"<div><a href='/logs/{entry['log_filename']}'>Download log</a></div>"
+                    "<h3>Round-by-round progress</h3>"
+                    "<table><tr><th>Round</th><th>Actor</th><th>Weighted Score</th><th>Actor Scores</th></tr>"
+                    + rows
+                    + "</table></section>"
+                )
+            )
+
+        return summary + "".join(sections) + "<a href='/'>Back</a>"
+
+    @app.route("/logs/<path:filename>", methods=["GET"])
+    def download_log(filename: str):
+        if filename not in known_logs:
+            logger.info("Unknown log requested: %s", filename)
+            abort(404)
+        log_dir = app.config["PLAYER_LOG_DIR"]
+        file_path = os.path.join(log_dir, filename)
+        if not os.path.isfile(file_path):
+            abort(404)
+        return send_from_directory(log_dir, filename, as_attachment=True)
 
     @app.route("/evaluation/baseline", methods=["POST"])
     def baseline_evaluation():

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
+import re
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
+import tempfile
 import yaml
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -16,37 +18,53 @@ FIXTURE_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "characters.y
 
 
 class PlayerServiceTest(unittest.TestCase):
-    def test_progress_page(self):
-        with patch("players.random.choice") as mock_choice, patch(
-            "rpg.character.genai"
-        ) as mock_char_genai, patch(
-            "rpg.assessment_agent.genai"
-        ) as mock_assess_genai, patch("players.genai") as mock_players_genai:
-            mock_action_model = MagicMock()
-            mock_assess_model = MagicMock()
-            mock_action_model.generate_content.return_value = MagicMock(
-                text="1. A\n2. B\n3. C"
+    def test_progress_page_lists_all_scores_and_logs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("players.random.choice") as mock_choice, patch(
+                "rpg.character.genai"
+            ) as mock_char_genai, patch(
+                "rpg.assessment_agent.genai"
+            ) as mock_assess_genai, patch("players.genai") as mock_players_genai:
+                mock_action_model = MagicMock()
+                mock_assess_model = MagicMock()
+                mock_action_model.generate_content.return_value = MagicMock(
+                    text="1. A\n2. B\n3. C"
+                )
+                mock_assess_model.generate_content.return_value = MagicMock(
+                    text="10\n20\n30"
+                )
+                mock_char_genai.GenerativeModel.return_value = mock_action_model
+                mock_assess_genai.GenerativeModel.return_value = mock_assess_model
+                mock_players_genai.GenerativeModel.return_value = MagicMock()
+                with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
+                    data = yaml.safe_load(fh)
+                character = YamlCharacter("test_character", data["test_character"])
+
+                def choice_side_effect(options):
+                    if options and isinstance(options[0], YamlCharacter):
+                        return character
+                    return "A"
+
+                mock_choice.side_effect = choice_side_effect
+                with patch("player_service.load_characters", return_value=[character]):
+                    app = create_app(log_dir=tmpdir)
+                    client = app.test_client()
+            resp = client.post(
+                "/",
+                data={"player": "random", "rounds": "1", "games": "2"},
+                follow_redirects=True,
             )
-            mock_assess_model.generate_content.return_value = MagicMock(
-                text="10\n20\n30"
-            )
-            mock_char_genai.GenerativeModel.return_value = mock_action_model
-            mock_assess_genai.GenerativeModel.return_value = mock_assess_model
-            mock_players_genai.GenerativeModel.return_value = MagicMock()
-            with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
-                data = yaml.safe_load(fh)
-            character = YamlCharacter("test_character", data["test_character"])
-            mock_choice.side_effect = [character, "A"]
-            with patch("player_service.load_characters", return_value=[character]):
-                app = create_app()
-                client = app.test_client()
-        resp = client.post(
-            "/", data={"player": "random", "rounds": "1"}, follow_redirects=True
-        )
-        page = resp.data.decode()
-        self.assertIn("Game Progress", page)
-        self.assertIn("test_character", page)
-        self.assertIn("Final weighted score", page)
+            page = resp.data.decode()
+            self.assertIn("Player Manager Progress", page)
+            self.assertIn("Game 1", page)
+            self.assertIn("Game 2", page)
+            self.assertIn("10, 20, 30", page)
+            self.assertIn("Download log", page)
+            log_links = re.findall(r"/logs/([^\"']+)", page)
+            self.assertGreaterEqual(len(log_links), 2)
+            log_resp = client.get(f"/logs/{log_links[0]}")
+            self.assertEqual(log_resp.status_code, 200)
+            self.assertTrue(log_resp.data)
 
     def test_evaluation_buttons_present(self):
         with patch("player_service.load_characters", return_value=[]), patch(


### PR DESCRIPTION
## Summary
- add a PlayerManager helper that runs automated games sequentially and captures detailed progress metadata plus per-run logs
- enhance the player service UI to configure multi-game runs, show per-actor score lists for every round, and expose downloadable log files for each game
- extend the player service tests to cover multi-game sequences, actor score rendering, and log download links

## Testing
- pytest tests/test_player_service.py

------
https://chatgpt.com/codex/tasks/task_e_68c96ecaab0083338dd6e5b0f8b6ebee