### PR TITLE
Update win threshold and parse actions from JSON

### DIFF
--- a/player_game.py
+++ b/player_game.py
@@ -10,7 +10,7 @@ import os
 from typing import Dict
 
 from cli_game import load_characters
-from rpg.game_state import GameState
+from rpg.game_state import GameState, WIN_THRESHOLD
 from rpg.assessment_agent import AssessmentAgent
 from players import RandomPlayer, GeminiWinPlayer, GeminiGovCorpPlayer
 
@@ -50,7 +50,7 @@ def main() -> None:
     for round_num in range(1, args.rounds + 1):
         logger.info("Round %d", round_num)
         player.take_turn(state, assessor)
-        if state.final_weighted_score() >= 80:
+        if state.final_weighted_score() >= WIN_THRESHOLD:
             logger.info("Final score threshold reached; ending game")
             break
 

--- a/player_manager.py
+++ b/player_manager.py
@@ -10,7 +10,7 @@ from typing import Dict, Iterable, List
 from uuid import uuid4
 
 from rpg.assessment_agent import AssessmentAgent
-from rpg.game_state import GameState
+from rpg.game_state import GameState, WIN_THRESHOLD
 from players import Player
 
 
@@ -111,7 +111,7 @@ class PlayerManager:
                 logger.info(
                     "Round %d result: actor=%s score=%s", round_index, actor, final_score
                 )
-                if final_score >= 80:
+                if final_score >= WIN_THRESHOLD:
                     logger.info(
                         "Final score threshold reached for game %d; ending early", game_index
                     )
@@ -126,7 +126,7 @@ class PlayerManager:
             "game_number": game_index,
             "rounds": rounds_progress,
             "final_score": final_score,
-            "result": "Win" if final_score >= 80 else "Lose",
+            "result": "Win" if final_score >= WIN_THRESHOLD else "Lose",
             "iterations": len(rounds_progress),
             "actions": len(state.history),
             "log_filename": log_filename,

--- a/rpg/game_state.py
+++ b/rpg/game_state.py
@@ -15,6 +15,9 @@ from .character import Character
 logger = logging.getLogger(__name__)
 
 
+WIN_THRESHOLD = 71
+
+
 @dataclass
 class GameState:
     """Store characters, their progress, and a history of actions."""

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import json
 import os
 import sys
 import unittest
@@ -23,7 +24,13 @@ class WebServiceTest(unittest.TestCase):
             mock_action_model = MagicMock()
             mock_assess_model = MagicMock()
             mock_action_model.generate_content.return_value = MagicMock(
-                text="1. A\n2. B\n3. C"
+                text=json.dumps(
+                    [
+                        {"text": "A", "related-triplet": 1},
+                        {"text": "B", "related-triplet": "None"},
+                        {"text": "C", "related-triplet": "None"},
+                    ]
+                )
             )
             mock_assess_model.generate_content.return_value = MagicMock(
                 text="90\n90\n90"
@@ -94,7 +101,13 @@ class WebServiceTest(unittest.TestCase):
             mock_action_model = MagicMock()
             mock_assess_model = MagicMock()
             mock_action_model.generate_content.return_value = MagicMock(
-                text="1. A\n2. B\n3. C"
+                text=json.dumps(
+                    [
+                        {"text": "A", "related-triplet": 1},
+                        {"text": "B", "related-triplet": "None"},
+                        {"text": "C", "related-triplet": "None"},
+                    ]
+                )
             )
             mock_assess_model.generate_content.return_value = MagicMock(
                 text="10\n20\n30"

--- a/web_service.py
+++ b/web_service.py
@@ -13,7 +13,7 @@ import queue
 from flask import Flask, request, redirect, Response
 
 from cli_game import load_characters
-from rpg.game_state import GameState
+from rpg.game_state import GameState, WIN_THRESHOLD
 from rpg.assessment_agent import AssessmentAgent
 
 # Link to this project's source code repository for inclusion in the web UI footer
@@ -61,7 +61,7 @@ def create_app() -> Flask:
         return (
             "<h1>AI Safety Negotiation Game</h1>"
             "<p>You are an expert negotiator with connection to all relevant actors in the AI safety world, you can convince them to propose and take actions.  your objective is to enure that ai is developed in the best interest of humanity. your goal is to keep the future human.</p>"
-            "<p>You have 10 turns to reach a final weighted score of 80 or higher to win.</p>"
+            "<p>You have 10 turns to reach a final weighted score of 71 or higher to win.</p>"
             "<a href='/start'>Start</a>"
             f"{footer}"
         )
@@ -75,7 +75,7 @@ def create_app() -> Flask:
             hist_snapshot = list(game_state.history)
             characters = list(game_state.characters)
             state_html = game_state.render_state()
-        if score >= 80 or len(hist_snapshot) >= 10:
+        if score >= WIN_THRESHOLD or len(hist_snapshot) >= 10:
             return redirect("/result")
 
         if enable_parallel:
@@ -218,7 +218,7 @@ def create_app() -> Flask:
         with state_lock:
             final_score = game_state.final_weighted_score()
             hist_len = len(game_state.history)
-        if final_score >= 80 or hist_len >= 10:
+        if final_score >= WIN_THRESHOLD or hist_len >= 10:
             return redirect("/result")
         return redirect("/start")
 
@@ -259,7 +259,7 @@ def create_app() -> Flask:
         with state_lock:
             final = game_state.final_weighted_score()
             state_html = game_state.render_state()
-        outcome = "You won!" if final >= 80 else "You lost!"
+        outcome = "You won!" if final >= WIN_THRESHOLD else "You lost!"
         return (
             f"<h1>{outcome}</h1>"
             f"{state_html}"


### PR DESCRIPTION
## Summary
- update the shared win threshold to 71 and apply it to the CLI runner, player manager, and web UI messaging
- change NPC action prompts to request JSON output, parse the structured response, and warn when zero or multiple triplets are referenced
- refresh character and web service tests to exercise JSON parsing and the new logging behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d290d937248333b3cad06f9b82e634