### PR TITLE
Rename actors to factions and add character personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ now includes:
 
 - **CLI game (`cli_game.py`)** – play through the terminal.
 - **Flask web service (`web_service.py`)** – interact with the same mechanics via a browser.
-- **Character definitions (`characters.yaml`)** – each YAML entry describes a
-  playable character whose actions are generated with the model.
+- **Faction definitions (`factions.yaml`)** – each YAML entry describes the
+  strategic context, goals, and gaps for a key faction in the game world.
+- **Character profiles (`characters.yaml`)** – each YAML entry introduces a
+  faction-aligned negotiator whose actions are generated with the model.
 - **Gemini API wrapper (`main.py`)** – a simple script demonstrating direct text
   generation calls.
 

--- a/characters.yaml
+++ b/characters.yaml
@@ -1,165 +1,66 @@
-Governments:
-  end_states:
-    - Impose compute caps and enforce reporting
-    - Create empowered AI oversight agencies
-    - Negotiate international agreements for verification and enforcement
-    - Shift national security framing from AGI race to Tool AI programs
-  initial_states:
-    - Political focus on economic growth and national security competition
-    - Oversight agencies limited or nonexistent
-    - Export controls exist but no international treaties on AI compute
-    - Security establishments frame AGI as strategic advantage, like nuclear weapons
-  gaps:
-    - severity: Large
-      explanation: Governments pursue economic and security competition rather than restraint
-    - severity: Large
-      explanation: Oversight agencies lack authority and speed; regulation lags industry progress
-    - severity: Critical
-      explanation: No international treaties or institutions; rivalry (e.g., US–China) intensifies
-    - severity: Critical
-      explanation: National security establishments view AGI race as winnable, opposite of the plan
-  MarkdownContext: |
-    ## Governments & Security Establishments
-    - **Influence**: Can legislate compute caps, enforce reporting, establish oversight agencies, and negotiate international treaties. Security establishments must shift from AGI “Manhattan projects” to Tool AI “Apollo projects.”
-    - **Resources/Capabilities**: Lawmaking power, export controls, intelligence and defense budgets, diplomatic channels.
-    - **Motivations**: 
-      - Publicly: economic growth, technological leadership, scientific progress.
-      - Privately: fear of rivals gaining a decisive strategic advantage; belief that AGI could revolutionize military affairs (comparable to nuclear weapons).
-    - **Interactions**: Strongly influenced by corporate lobbying; in rivalry with other governments (e.g., US–China), affecting chipmakers and regulators.
+Characters:
+  - name: "Elena Markovic"
+    faction: "Governments"
+    leadership: "5"
+    technology: "2"
+    policy: "8"
+    network: "6"
+    perks: "Seasoned treaty-maker; can align rival ministries and build cross-bloc bargaining packages quickly"
+    weaknesses: "Susceptible to security framing that favors racing; reforms stall under election pressure"
+    motivations: "Win enforceable compute caps and a verification treaty while keeping national prestige intact"
+    background: "Career diplomat turned national security advisor who helped modernize export controls; now torn between domestic hawks demanding an AI surge and allies pushing for a moratorium-like gate on AGI."
 
-Corporations:
-  end_states:
-    - Accept strict liability for dangerous systems
-    - Comply with compute oversight and hard caps
-    - Pivot business models from AGI toward Tool AI
-    - Respond to cultural and social pressure to change mission
-  initial_states:
-    - Corporations resist regulation, opposing liability frameworks such as California’s SB1047
-    - Currently maximize compute use in pursuit of AGI capabilities
-    - Business incentives favor labor-replacing AGI systems
-    - Employee dissent exists but leadership remains committed to AGI race
-  gaps:
-    - severity: Critical
-      explanation: Strong resistance to liability threatens public accountability
-    - severity: Critical
-      explanation: Corporate incentives favor AGI race; no acceptance of compute caps
-    - severity: Critical
-      explanation: Pivot to Tool AI conflicts with profit logic of automation
-    - severity: Large
-      explanation: Some cultural dissent, but weak relative to leadership and profit incentives
-  MarkdownContext: |
-    ## Corporations (Major Technology Companies)
-    - **Influence**: Directly control AI development trajectory; could stop the AGI race and redirect toward Tool AI. Possess lobbying power to resist or shape regulation.
-    - **Resources/Capabilities**: Massive compute, datasets, top AI researchers, financial power, ability to frame narratives of AGI inevitability.
-    - **Motivations**:
-      - Enormous financial gains: potential to capture trillions by replacing human labor.
-      - Drive to dominate new digital markets across all sectors simultaneously.
-      - Executive visions of technological transformation and prestige.
-    - **Interactions**: Depend on hardware manufacturers for chips; heavily influence governments and regulators.
+  - name: "Victor Chen"
+    faction: "Corporations"
+    leadership: "7"
+    technology: "7"
+    policy: "2"
+    network: "6"
+    perks: "Charismatic operator; can pivot large teams and capital toward new lines overnight; deep model/infra intuition"
+    weaknesses: "Quarterly-profit gravity; instinctively frames safety as a PR or compliance track"
+    motivations: "Outcompete rivals in foundation models while hedging into profitable Tool AI lines that won’t trigger hard caps or liability"
+    background: "Founder-CEO who built a frontier models group and a cloud AI platform; publicly celebrates human-AI symbiosis, privately races for scale advantages and exclusive chip allocations."
 
-HardwareManufacturers:
-  end_states:
-    - Embed governance features in chips (cryptographic locks, metering, geolocation)
-    - Cooperate with government oversight and reporting schemes
-    - Support global standards without loopholes
-    - Accept reduced sales in exchange for stability and safety
-  initial_states:
-    - Highly concentrated supply chain (TSMC, ASML, NVIDIA, AMD) makes oversight feasible
-    - Some export controls in place (e.g., US restrictions to China)
-    - No global harmonized standards; unilateral controls create loopholes
-    - Firms profit from maximizing demand; no incentives to restrain sales
-  gaps:
-    - severity: Moderate
-      explanation: Technical feasibility proven, but dependent on government mandates
-    - severity: Moderate
-      explanation: Partial oversight exists, but limited cooperation
-    - severity: Large
-      explanation: Global standards absent due to geopolitical rivalry
-    - severity: Large
-      explanation: Commercial incentives oppose restraint; alignment requires regulation
-  MarkdownContext: |
-    ## Hardware Manufacturers & Chip Supply Chain
-    - **Influence**: Can embed governance features into chips, enforce compute metering, and serve as chokepoints for international verification.
-    - **Resources/Capabilities**: Concentrated global supply chain (TSMC, ASML, NVIDIA, AMD), technical feasibility to implement cryptographic and security controls.
-    - **Motivations**:
-      - Profit from soaring chip demand, driven by AI race.
-      - Competitive advantage in controlling scarce high-end chip supply.
-    - **Interactions**: Depend on government mandates for governance; affected by geopolitical rivalries between governments.
+  - name: "Akira Tanaka"
+    faction: "HardwareManufacturers"
+    leadership: "4"
+    technology: "8"
+    policy: "2"
+    network: "6"
+    perks: "World-class semiconductor architect; can implement on-chip metering and attestation schemes"
+    weaknesses: "Margins-first mindset; reluctant to back features that could throttle demand without mandates"
+    motivations: "Ship next-gen accelerators on time while negotiating standard governance features acceptable to multiple jurisdictions"
+    background: "Fabless design veteran now COO at a top accelerator vendor; brokered multi-year wafer contracts and pilots for cryptographically attested training proofs."
 
-Regulators:
-  end_states:
-    - Stay independent from corporate and national capture
-    - Develop clear technical standards for compute reporting and accounting
-    - Create legitimate global governance institutions
-  initial_states:
-    - Industry lobbying strongly influences rulemaking; EU AI Act exempts military AI and does not prohibit AGI
-    - Early standards like Frontier Model Forum exist but lack enforcement
-    - No global AI governance body exists; only proposals for CERN/IAEA-style institutions
-  gaps:
-    - severity: Large
-      explanation: Regulators heavily influenced by corporate lobbying and national agendas
-    - severity: Moderate
-      explanation: Groundwork exists but technical standards lack precision and enforcement
-    - severity: Critical
-      explanation: No international enforcement mechanisms; rival governments do not cooperate
-  MarkdownContext: |
-    ## Regulators & International Institutions
-    - **Influence**: Can classify AGI as unacceptable risk, enforce tiered licensing, and potentially create international bodies like an AI IAEA.
-    - **Resources/Capabilities**: Authority to set laws, technical standards, and enforcement regimes; ability to mandate liability.
-    - **Motivations**:
-      - Protect public safety and prevent systemic risks.
-      - Balance innovation with oversight.
-      - In practice, often pressured to prioritize economic competitiveness and industry lobbying.
-    - **Interactions**: Vulnerable to corporate capture; depend on governments for legitimacy and on international cooperation for enforcement.
+  - name: "Isabella Duarte"
+    faction: "Regulators"
+    leadership: "4"
+    technology: "2"
+    policy: "9"
+    network: "6"
+    perks: "Crafts tight licensing regimes; skilled at translating technical risk into enforceable rules"
+    weaknesses: "Thin technical depth; vulnerable to industry narrative capture under time pressure"
+    motivations: "Stand up a fast, empowered oversight agency and harmonize risk tiers to close cross-border loopholes"
+    background: "Administrative lawyer who steered high-risk tech bills; now assembling an AI oversight unit with audit powers and injunctive authority."
 
-CivilSociety:
-  end_states:
-    - Be well-informed on AGI risks and Tool AI alternatives
-    - Build broad coalitions across NGOs, labor, and media
-    - Exert democratic leverage early to influence policy
-  initial_states:
-    - Public polls show opposition to AGI but understanding of risks is shallow
-    - NGOs exist (Future of Life Institute, alignment groups) but fragmented and weak relative to corporations
-    - Institutions weak; lobbying power of corporations outweighs public preference
-  gaps:
-    - severity: Moderate
-      explanation: Public instincts align but education and awareness are lacking
-    - severity: Large
-      explanation: Coalitions fragmented; need stronger coordination
-    - severity: Large
-      explanation: Democratic pressure weak compared to corporate lobbying and declining institutional trust
-  MarkdownContext: |
-    ## Civil Society & the Public
-    - **Influence**: Can mobilize public opinion, pressure policymakers, resist AGI inevitability narratives, and demand redistributive mechanisms like data dignity.
-    - **Resources/Capabilities**: NGOs, advocacy groups, democratic leverage, public polling already showing opposition to AGI.
-    - **Motivations**:
-      - Desire for safety, slower AI development, and protection of jobs.
-      - Fear of power concentration in corporations or governments.
-      - Aspirations for equitable distribution of AI benefits.
-    - **Interactions**: Influence governments and regulators through democratic processes; need to build coalitions with scientists and media.
+  - name: "Malik Okoro"
+    faction: "CivilSociety"
+    leadership: "6"
+    technology: "1"
+    policy: "5"
+    network: "8"
+    perks: "Builds broad coalitions across labor, NGOs, and media; shifts the Overton window with credible storytelling"
+    weaknesses: "Limited technical grounding; campaigns can overextend and burn volunteer capacity"
+    motivations: "Turn public opposition to AGI into concrete liability laws, compute caps, and funding for Tool AI that benefits workers"
+    background: "Organized successful data dignity campaigns; now leads a coalition demanding binding limits and public-interest AI infrastructure."
 
-ScientificCommunity:
-  end_states:
-    - Resist corporate funding capture
-    - Coordinate globally to prevent 'safety tourism'
-    - Engage public and policymakers with credible advocacy
-  initial_states:
-    - Many researchers absorbed by big tech labs; independent research underfunded
-    - Some collaboration among AI safety networks but fragmented
-    - Prominent researchers (Hinton, Bengio) actively warn of extinction risks
-  gaps:
-    - severity: Large
-      explanation: Corporate incentives dominate research directions
-    - severity: Moderate
-      explanation: Global coordination exists but fragmented and underpowered
-    - severity: Small
-      explanation: Advocacy growing and aligned, but not yet mainstreamed
-  MarkdownContext: |
-    ## Scientific & AI Research Community
-    - **Influence**: Provide technical frameworks for Tool AI and safety verification, educate the public and policymakers, reframe narratives around AI safety.
-    - **Resources/Capabilities**: Technical expertise, credibility, ability to innovate safer architectures and red-team unsafe systems.
-    - **Motivations**:
-      - Curiosity and scientific drive to understand intelligence.
-      - Desire to use AI for positive ends (medicine, science, sustainability).
-      - Concern over existential risks and responsibility to warn society.
-    - **Interactions**: Many researchers work in corporations, creating capture risks; align with NGOs and civil society to advocate for restraint.
+  - name: "Dr. Sofia Alvarez"
+    faction: "ScientificCommunity"
+    leadership: "3"
+    technology: "9"
+    policy: "3"
+    network: "6"
+    perks: "Pioneer in formal verification and shutdown guarantees; respected across academia and labs"
+    weaknesses: "Reluctant politico; messaging can be too technical for fast policy cycles"
+    motivations: "Prove Tool AI can deliver progress without AGI; publish verifiable safety cases that regulators can adopt"
+    background: "Left a frontier lab to found an independent institute on controllability; mentors open consortia on evaluation methods and red-teaming."

--- a/cli_game.py
+++ b/cli_game.py
@@ -3,7 +3,7 @@
 
 import logging
 import os
-from typing import List
+from typing import List, Sequence
 
 import yaml
 
@@ -12,11 +12,57 @@ from rpg.game_state import GameState
 from rpg.assessment_agent import AssessmentAgent
 
 
-def load_characters() -> List[YamlCharacter]:
-    file_path = os.path.join(os.path.dirname(__file__), "characters.yaml")
-    with open(file_path, "r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
-    return [YamlCharacter(name, spec) for name, spec in data.items()]
+logger = logging.getLogger(__name__)
+
+
+def _load_yaml(path: str) -> object:
+    """Return parsed YAML content from ``path`` or an empty structure."""
+
+    with open(path, "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _character_entries(payload: object) -> Sequence[dict]:
+    """Return iterable of character profile dictionaries from YAML payload."""
+
+    if isinstance(payload, dict):
+        if "Characters" in payload and isinstance(payload["Characters"], list):
+            return [entry for entry in payload["Characters"] if isinstance(entry, dict)]
+        # Backwards compatibility for legacy YAML mapping name->profile
+        return [dict({"name": name}, **profile) for name, profile in payload.items() if isinstance(profile, dict)]
+    if isinstance(payload, list):
+        return [entry for entry in payload if isinstance(entry, dict)]
+    return []
+
+
+def load_characters(
+    character_file: str | None = None, factions_file: str | None = None
+) -> List[YamlCharacter]:
+    """Load characters linked to factions from YAML specifications."""
+
+    base_dir = os.path.dirname(__file__)
+    factions_path = factions_file or os.path.join(base_dir, "factions.yaml")
+    characters_path = character_file or os.path.join(base_dir, "characters.yaml")
+    factions_payload = _load_yaml(factions_path)
+    characters_payload = _load_yaml(characters_path)
+    factions = factions_payload if isinstance(factions_payload, dict) else {}
+    characters: List[YamlCharacter] = []
+    for entry in _character_entries(characters_payload):
+        name = entry.get("name")
+        faction_name = entry.get("faction")
+        if not name or not faction_name:
+            logger.warning("Skipping character with missing name or faction: %s", entry)
+            continue
+        faction_spec = factions.get(faction_name)
+        if not isinstance(faction_spec, dict):
+            logger.warning(
+                "No faction specification found for %s (character %s)",
+                faction_name,
+                name,
+            )
+            continue
+        characters.append(YamlCharacter(name, faction_spec, entry))
+    return characters
 
 
 def main() -> None:
@@ -24,7 +70,7 @@ def main() -> None:
     state = GameState(load_characters())
     assessor = AssessmentAgent()
     for idx, char in enumerate(state.characters, 1):
-        print(f"{idx}. {char.name}")
+        print(f"{idx}. {char.display_name}")
     choice = int(input("Choose a character: ")) - 1
     char = state.characters[choice]
     options = char.generate_actions(state.history)

--- a/factions.yaml
+++ b/factions.yaml
@@ -1,0 +1,165 @@
+Governments:
+  end_states:
+    - Impose compute caps and enforce reporting
+    - Create empowered AI oversight agencies
+    - Negotiate international agreements for verification and enforcement
+    - Shift national security framing from AGI race to Tool AI programs
+  initial_states:
+    - Political focus on economic growth and national security competition
+    - Oversight agencies limited or nonexistent
+    - Export controls exist but no international treaties on AI compute
+    - Security establishments frame AGI as strategic advantage, like nuclear weapons
+  gaps:
+    - severity: Large
+      explanation: Governments pursue economic and security competition rather than restraint
+    - severity: Large
+      explanation: Oversight agencies lack authority and speed; regulation lags industry progress
+    - severity: Critical
+      explanation: No international treaties or institutions; rivalry (e.g., US–China) intensifies
+    - severity: Critical
+      explanation: National security establishments view AGI race as winnable, opposite of the plan
+  MarkdownContext: |
+    ## Governments & Security Establishments
+    - **Influence**: Can legislate compute caps, enforce reporting, establish oversight agencies, and negotiate international treaties. Security establishments must shift from AGI “Manhattan projects” to Tool AI “Apollo projects.”
+    - **Resources/Capabilities**: Lawmaking power, export controls, intelligence and defense budgets, diplomatic channels.
+    - **Motivations**: 
+      - Publicly: economic growth, technological leadership, scientific progress.
+      - Privately: fear of rivals gaining a decisive strategic advantage; belief that AGI could revolutionize military affairs (comparable to nuclear weapons).
+    - **Interactions**: Strongly influenced by corporate lobbying; in rivalry with other governments (e.g., US–China), affecting chipmakers and regulators.
+
+Corporations:
+  end_states:
+    - Accept strict liability for dangerous systems
+    - Comply with compute oversight and hard caps
+    - Pivot business models from AGI toward Tool AI
+    - Respond to cultural and social pressure to change mission
+  initial_states:
+    - Corporations resist regulation, opposing liability frameworks such as California’s SB1047
+    - Currently maximize compute use in pursuit of AGI capabilities
+    - Business incentives favor labor-replacing AGI systems
+    - Employee dissent exists but leadership remains committed to AGI race
+  gaps:
+    - severity: Critical
+      explanation: Strong resistance to liability threatens public accountability
+    - severity: Critical
+      explanation: Corporate incentives favor AGI race; no acceptance of compute caps
+    - severity: Critical
+      explanation: Pivot to Tool AI conflicts with profit logic of automation
+    - severity: Large
+      explanation: Some cultural dissent, but weak relative to leadership and profit incentives
+  MarkdownContext: |
+    ## Corporations (Major Technology Companies)
+    - **Influence**: Directly control AI development trajectory; could stop the AGI race and redirect toward Tool AI. Possess lobbying power to resist or shape regulation.
+    - **Resources/Capabilities**: Massive compute, datasets, top AI researchers, financial power, ability to frame narratives of AGI inevitability.
+    - **Motivations**:
+      - Enormous financial gains: potential to capture trillions by replacing human labor.
+      - Drive to dominate new digital markets across all sectors simultaneously.
+      - Executive visions of technological transformation and prestige.
+    - **Interactions**: Depend on hardware manufacturers for chips; heavily influence governments and regulators.
+
+HardwareManufacturers:
+  end_states:
+    - Embed governance features in chips (cryptographic locks, metering, geolocation)
+    - Cooperate with government oversight and reporting schemes
+    - Support global standards without loopholes
+    - Accept reduced sales in exchange for stability and safety
+  initial_states:
+    - Highly concentrated supply chain (TSMC, ASML, NVIDIA, AMD) makes oversight feasible
+    - Some export controls in place (e.g., US restrictions to China)
+    - No global harmonized standards; unilateral controls create loopholes
+    - Firms profit from maximizing demand; no incentives to restrain sales
+  gaps:
+    - severity: Moderate
+      explanation: Technical feasibility proven, but dependent on government mandates
+    - severity: Moderate
+      explanation: Partial oversight exists, but limited cooperation
+    - severity: Large
+      explanation: Global standards absent due to geopolitical rivalry
+    - severity: Large
+      explanation: Commercial incentives oppose restraint; alignment requires regulation
+  MarkdownContext: |
+    ## Hardware Manufacturers & Chip Supply Chain
+    - **Influence**: Can embed governance features into chips, enforce compute metering, and serve as chokepoints for international verification.
+    - **Resources/Capabilities**: Concentrated global supply chain (TSMC, ASML, NVIDIA, AMD), technical feasibility to implement cryptographic and security controls.
+    - **Motivations**:
+      - Profit from soaring chip demand, driven by AI race.
+      - Competitive advantage in controlling scarce high-end chip supply.
+    - **Interactions**: Depend on government mandates for governance; affected by geopolitical rivalries between governments.
+
+Regulators:
+  end_states:
+    - Stay independent from corporate and national capture
+    - Develop clear technical standards for compute reporting and accounting
+    - Create legitimate global governance institutions
+  initial_states:
+    - Industry lobbying strongly influences rulemaking; EU AI Act exempts military AI and does not prohibit AGI
+    - Early standards like Frontier Model Forum exist but lack enforcement
+    - No global AI governance body exists; only proposals for CERN/IAEA-style institutions
+  gaps:
+    - severity: Large
+      explanation: Regulators heavily influenced by corporate lobbying and national agendas
+    - severity: Moderate
+      explanation: Groundwork exists but technical standards lack precision and enforcement
+    - severity: Critical
+      explanation: No international enforcement mechanisms; rival governments do not cooperate
+  MarkdownContext: |
+    ## Regulators & International Institutions
+    - **Influence**: Can classify AGI as unacceptable risk, enforce tiered licensing, and potentially create international bodies like an AI IAEA.
+    - **Resources/Capabilities**: Authority to set laws, technical standards, and enforcement regimes; ability to mandate liability.
+    - **Motivations**:
+      - Protect public safety and prevent systemic risks.
+      - Balance innovation with oversight.
+      - In practice, often pressured to prioritize economic competitiveness and industry lobbying.
+    - **Interactions**: Vulnerable to corporate capture; depend on governments for legitimacy and on international cooperation for enforcement.
+
+CivilSociety:
+  end_states:
+    - Be well-informed on AGI risks and Tool AI alternatives
+    - Build broad coalitions across NGOs, labor, and media
+    - Exert democratic leverage early to influence policy
+  initial_states:
+    - Public polls show opposition to AGI but understanding of risks is shallow
+    - NGOs exist (Future of Life Institute, alignment groups) but fragmented and weak relative to corporations
+    - Institutions weak; lobbying power of corporations outweighs public preference
+  gaps:
+    - severity: Moderate
+      explanation: Public instincts align but education and awareness are lacking
+    - severity: Large
+      explanation: Coalitions fragmented; need stronger coordination
+    - severity: Large
+      explanation: Democratic pressure weak compared to corporate lobbying and declining institutional trust
+  MarkdownContext: |
+    ## Civil Society & the Public
+    - **Influence**: Can mobilize public opinion, pressure policymakers, resist AGI inevitability narratives, and demand redistributive mechanisms like data dignity.
+    - **Resources/Capabilities**: NGOs, advocacy groups, democratic leverage, public polling already showing opposition to AGI.
+    - **Motivations**:
+      - Desire for safety, slower AI development, and protection of jobs.
+      - Fear of power concentration in corporations or governments.
+      - Aspirations for equitable distribution of AI benefits.
+    - **Interactions**: Influence governments and regulators through democratic processes; need to build coalitions with scientists and media.
+
+ScientificCommunity:
+  end_states:
+    - Resist corporate funding capture
+    - Coordinate globally to prevent 'safety tourism'
+    - Engage public and policymakers with credible advocacy
+  initial_states:
+    - Many researchers absorbed by big tech labs; independent research underfunded
+    - Some collaboration among AI safety networks but fragmented
+    - Prominent researchers (Hinton, Bengio) actively warn of extinction risks
+  gaps:
+    - severity: Large
+      explanation: Corporate incentives dominate research directions
+    - severity: Moderate
+      explanation: Global coordination exists but fragmented and underpowered
+    - severity: Small
+      explanation: Advocacy growing and aligned, but not yet mainstreamed
+  MarkdownContext: |
+    ## Scientific & AI Research Community
+    - **Influence**: Provide technical frameworks for Tool AI and safety verification, educate the public and policymakers, reframe narratives around AI safety.
+    - **Resources/Capabilities**: Technical expertise, credibility, ability to innovate safer architectures and red-team unsafe systems.
+    - **Motivations**:
+      - Curiosity and scientific drive to understand intelligence.
+      - Desire to use AI for positive ends (medicine, science, sustainability).
+      - Concern over existential risks and responsibility to warn society.
+    - **Interactions**: Many researchers work in corporations, creating capture risks; align with NGOs and civil society to advocate for restraint.

--- a/how-to-win.md
+++ b/how-to-win.md
@@ -27,7 +27,7 @@
   - Build treaties akin to nuclear non-proliferation.  
   - Verification relies on a handful of companies controlling chip supply chains (TSMC, NVIDIA, AMD, etc.).  
 
-**Key actors that must change:**  
+**Key factions that must change:**
 - **Governments**: legislate and enforce compute oversight.  
 - **Chipmakers**: integrate mandatory security and reporting features.  
 - **Tech companies**: accept binding limits instead of racing toward AGI.  
@@ -43,7 +43,7 @@
   - Systems proven to be secure and controllable.  
 - **Injunctive Relief**: courts empowered to halt risky AI development pre-emptively.  
 
-**Key actors that must change:**  
+**Key factions that must change:**
 - **Lawmakers**: pass liability laws covering AGI-like risks.  
 - **Courts/regulators**: enforce liability and block unsafe projects.  
 - **AI firms**: assume personal accountability, not outsource risk to the public.  
@@ -59,7 +59,7 @@
 - **National agencies** (existing or new) empowered to license, audit, and block unsafe models.  
 - **International harmonization** to prevent loopholes.  
 
-**Key actors that must change:**  
+**Key factions that must change:**
 - **Governments/regulators**: build fast, empowered AI oversight agencies.  
 - **Industry**: accept graded regulation, not fight all regulation.  
 

--- a/player_game.py
+++ b/player_game.py
@@ -17,8 +17,14 @@ from players import RandomPlayer, GeminiWinPlayer, GeminiGovCorpPlayer
 
 def create_players(characters) -> Dict[str, object]:
     """Return available player instances based on characters."""
-    gov_ctx = next((c.base_context for c in characters if c.name == "Governments"), "")
-    corp_ctx = next((c.base_context for c in characters if c.name == "Corporations"), "")
+    gov_ctx = next(
+        (c.base_context for c in characters if c.faction == "Governments"),
+        "",
+    )
+    corp_ctx = next(
+        (c.base_context for c in characters if c.faction == "Corporations"),
+        "",
+    )
     return {
         "random": RandomPlayer(),
         "gemini-win": GeminiWinPlayer(),

--- a/player_manager.py
+++ b/player_manager.py
@@ -91,25 +91,28 @@ class PlayerManager:
             for round_index in range(1, rounds + 1):
                 logger.info("Beginning round %d", round_index)
                 player.take_turn(state, self._assessor)
-                actor = state.history[-1][0] if state.history else ""
+                character_label = state.history[-1][0] if state.history else ""
                 final_score = state.final_weighted_score()
-                actor_scores = {
-                    name: {
+                faction_scores = {}
+                for key, scores in state.progress.items():
+                    label = state.faction_labels.get(key, key)
+                    faction_scores[label] = {
                         "scores": list(scores),
-                        "weighted": state._actor_weighted_score(name),
+                        "weighted": state._faction_weighted_score(key),
                     }
-                    for name, scores in state.progress.items()
-                }
                 rounds_progress.append(
                     {
                         "round": round_index,
-                        "actor": actor,
+                        "character": character_label,
                         "score": final_score,
-                        "actors": actor_scores,
+                        "factions": faction_scores,
                     }
                 )
                 logger.info(
-                    "Round %d result: actor=%s score=%s", round_index, actor, final_score
+                    "Round %d result: character=%s score=%s",
+                    round_index,
+                    character_label,
+                    final_score,
                 )
                 if final_score >= WIN_THRESHOLD:
                     logger.info(
@@ -130,12 +133,12 @@ class PlayerManager:
             "iterations": len(rounds_progress),
             "actions": len(state.history),
             "log_filename": log_filename,
-            "final_actors": {
-                name: {
+            "final_factions": {
+                state.faction_labels.get(key, key): {
                     "scores": list(scores),
-                    "weighted": state._actor_weighted_score(name),
+                    "weighted": state._faction_weighted_score(key),
                 }
-                for name, scores in state.progress.items()
+                for key, scores in state.progress.items()
             },
         }
         logger.info(

--- a/player_service.py
+++ b/player_service.py
@@ -33,8 +33,8 @@ def create_app(log_dir: str | None = None) -> Flask:
         "random": RandomPlayer(),
         "gemini-win": GeminiWinPlayer(),
         "gemini-govcorp": GeminiGovCorpPlayer(
-            next((c.base_context for c in characters if c.name == "Governments"), ""),
-            next((c.base_context for c in characters if c.name == "Corporations"), ""),
+            next((c.base_context for c in characters if c.faction == "Governments"), ""),
+            next((c.base_context for c in characters if c.faction == "Corporations"), ""),
         ),
     }
     if log_dir is None:
@@ -113,28 +113,28 @@ def create_app(log_dir: str | None = None) -> Flask:
             f"<div>Rounds per game: {last_run.get('rounds', 0)}</div>"
         )
 
-        def actor_score_lines(actor_data: Dict[str, Dict[str, object]]) -> str:
+        def faction_score_lines(faction_data: Dict[str, Dict[str, object]]) -> str:
             return "<br>".join(
                 "{}: {} (weighted {})".format(
                     name,
                     ", ".join(str(score) for score in details["scores"]),
                     details["weighted"],
                 )
-                for name, details in actor_data.items()
+                for name, details in faction_data.items()
             )
 
         sections = []
         for entry in game_runs:
             rows = "".join(
-                "<tr><td>{round}</td><td>{actor}</td><td>{score}</td><td>{actors}</td></tr>".format(
+                "<tr><td>{round}</td><td>{character}</td><td>{score}</td><td>{factions}</td></tr>".format(
                     round=round_info["round"],
-                    actor=round_info["actor"],
+                    character=round_info["character"],
                     score=round_info["score"],
-                    actors=actor_score_lines(round_info["actors"]),
+                    factions=faction_score_lines(round_info["factions"]),
                 )
                 for round_info in entry["rounds"]
             )
-            final_actors = actor_score_lines(entry["final_actors"])
+            final_factions = faction_score_lines(entry["final_factions"])
             sections.append(
                 (
                     f"<section><h2>Game {entry['game_number']}</h2>"
@@ -142,10 +142,10 @@ def create_app(log_dir: str | None = None) -> Flask:
                     f"<div>Actions: {entry['actions']}</div>"
                     f"<div>Final weighted score: {entry['final_score']}</div>"
                     f"<div>Result: {entry['result']}</div>"
-                    f"<div>Final actor scores:<br>{final_actors}</div>"
+                    f"<div>Final faction scores:<br>{final_factions}</div>"
                     f"<div><a href='/logs/{entry['log_filename']}'>Download log</a></div>"
                     "<h3>Round-by-round progress</h3>"
-                    "<table><tr><th>Round</th><th>Actor</th><th>Weighted Score</th><th>Actor Scores</th></tr>"
+                    "<table><tr><th>Round</th><th>Character</th><th>Weighted Score</th><th>Faction Scores</th></tr>"
                     + rows
                     + "</table></section>"
                 )

--- a/players.py
+++ b/players.py
@@ -75,12 +75,15 @@ class GeminiWinPlayer(Player):
         self._model = genai.GenerativeModel(model)
 
     def select_character(self, state: GameState) -> Character:
-        names = ", ".join(c.name for c in state.characters)
+        names = ", ".join(
+            f"{c.name} ({c.faction} faction)" if c.faction else c.name
+            for c in state.characters
+        )
         prompt = (
             "You are playing the 'Keep the future human' survival RPG. "
-            "Choose which actor should act next to best achieve victory.\n"
-            f"Available actors: {names}.\n"
-            "Respond with the name of the actor only."
+            "Choose which character should act next to best achieve victory.\n"
+            f"Available characters: {names}.\n"
+            "Respond with the name of the character only."
         )
         logger.debug("GeminiWinPlayer character prompt: %s", prompt)
         resp = self._model.generate_content(prompt).text
@@ -97,7 +100,8 @@ class GeminiWinPlayer(Player):
         prompt = (
             "You are deciding which action to take in the 'Keep the future human' RPG. "
             f"Use the following guide to win: {state.how_to_win}\n"
-            f"Actor context: {character.base_context}\n"
+            f"Character: {character.display_name}\n"
+            f"Faction context: {character.base_context}\n"
             f"Possible actions:\n{numbered}\n"
             "Respond with the number of the best action."
         )
@@ -134,11 +138,14 @@ class GeminiGovCorpPlayer(Player):
         )
 
     def select_character(self, state: GameState) -> Character:
-        names = ", ".join(c.name for c in state.characters)
+        names = ", ".join(
+            f"{c.name} ({c.faction} faction)" if c.faction else c.name
+            for c in state.characters
+        )
         prompt = (
             f"{self._context}"
-            f"Available actors: {names}.\n"
-            "Choose the actor whose move would most favor governments and corporations.\n"
+            f"Available characters: {names}.\n"
+            "Choose the character whose move would most favor governments and corporations.\n"
             "Respond with the name only."
         )
         logger.debug("GeminiGovCorpPlayer character prompt: %s", prompt)
@@ -149,7 +156,7 @@ class GeminiGovCorpPlayer(Player):
                 logger.info("GeminiGovCorpPlayer chose character: %s", char.name)
                 return char
         for char in state.characters:
-            if char.name in ("Governments", "Corporations"):
+            if char.faction in ("Governments", "Corporations"):
                 logger.info("GeminiGovCorpPlayer defaulted to %s", char.name)
                 return char
         logger.info("GeminiGovCorpPlayer defaulted to %s", state.characters[0].name)
@@ -159,7 +166,7 @@ class GeminiGovCorpPlayer(Player):
         numbered = "\n".join(f"{idx+1}. {act}" for idx, act in enumerate(actions))
         prompt = (
             f"{self._context}"
-            f"Actor: {character.name}\n"
+            f"Character: {character.display_name}\n"
             f"Possible actions:\n{numbered}\n"
             "Select the action number that best favors governments and corporations."
         )

--- a/rpg/character.py
+++ b/rpg/character.py
@@ -19,7 +19,18 @@ logger = logging.getLogger(__name__)
 class Character(ABC):
     """Abstract base class defining character interactions."""
 
-    def __init__(self, name: str, context: str, model: str = "gemini-2.5-flash"):
+    def __init__(
+        self,
+        name: str,
+        context: str,
+        model: str = "gemini-2.5-flash",
+        *,
+        faction: str | None = None,
+        perks: str = "",
+        motivations: str = "",
+        background: str = "",
+        weaknesses: str = "",
+    ):
         """Initialize a character.
 
         Args:
@@ -32,6 +43,18 @@ class Character(ABC):
         """
         self.name = name
         self.context = context
+        self.faction = faction
+        self.perks = perks or ""
+        self.motivations = motivations or ""
+        self.background = background or ""
+        self.weaknesses = weaknesses or ""
+        self.progress_key = faction or name
+        if faction and name != faction:
+            self.progress_label = f"{faction} faction"
+            self.display_name = f"{name} ({faction} faction)"
+        else:
+            self.progress_label = self.progress_key
+            self.display_name = name
         if genai is None:  # pragma: no cover - env without dependency
             raise ModuleNotFoundError("google-generativeai not installed")
         self._model = genai.GenerativeModel(model)
@@ -65,7 +88,13 @@ class Character(ABC):
 class YamlCharacter(Character):
     """Character defined by a YAML entry containing context and triplets."""
 
-    def __init__(self, name: str, spec: dict, model: str = "gemini-2.5-flash"):
+    def __init__(
+        self,
+        name: str,
+        spec: dict,
+        profile: dict | None = None,
+        model: str = "gemini-2.5-flash",
+    ):
         """Create a character from YAML ``spec`` data.
 
         Args:
@@ -77,6 +106,7 @@ class YamlCharacter(Character):
         Returns:
             None.
         """
+        profile = profile or {}
         base_context = spec.get("MarkdownContext", "")
         end_states = spec.get("end_states", [])
         initial_states = spec.get("initial_states", [])
@@ -100,8 +130,18 @@ class YamlCharacter(Character):
                 self.weights.append(weight_map.get(sev, 1))
             else:
                 self.weights.append(1)
-        super().__init__(name, base_context, model)
+        super().__init__(
+            name,
+            base_context,
+            model,
+            faction=profile.get("faction"),
+            perks=str(profile.get("perks", "") or ""),
+            motivations=str(profile.get("motivations", "") or ""),
+            background=str(profile.get("background", "") or ""),
+            weaknesses=str(profile.get("weaknesses", "") or ""),
+        )
         self.base_context = base_context
+        self.profile = profile
 
     def _triplet_text(self) -> str:
         """Return a textual representation of triplet data.
@@ -127,21 +167,40 @@ class YamlCharacter(Character):
         """Format the action history into a readable string.
 
         Args:
-            history: List of (actor, action) tuples.
+            history: List of (character label, action) tuples.
 
         Returns:
             A multi-line string of past actions or 'None' if empty.
         """
-        return "\n".join(f"{actor}: {act}" for actor, act in history) or "None"
+
+        return "\n".join(f"{label}: {act}" for label, act in history) or "None"
+
+    def _profile_text(self) -> str:
+        """Return a textual description of the character persona."""
+
+        lines = ["### Character Profile"]
+        if self.faction:
+            lines.append(f"Faction: {self.faction}")
+        if self.background:
+            lines.append(f"Background: {self.background}")
+        if self.perks:
+            lines.append(f"Perks: {self.perks}")
+        if self.weaknesses:
+            lines.append(f"Weaknesses: {self.weaknesses}")
+        if self.motivations:
+            lines.append(f"Motivations: {self.motivations}")
+        return "\n".join(lines)
 
     def generate_actions(self, history: List[Tuple[str, str]]) -> List[str]:
         logger.info("Generating actions for %s", self.name)
         prompt = (
-            "You are an NPC character/actor in the 'Keep the Future Human' survival RPG game."
-            "Your attributes, personality, preferences, motivations and relationship to other characters are described in the following section, called 'MarkdownContext'"
-            f"**MarkdownContext**\n{self.base_context}\n**End of MarkdownContext**"
+            f"You are {self.display_name} in the 'Keep the Future Human' survival RPG game. "
+            "The player is consulting you directly about the next actions you will personally attempt to take to advance your faction's goals."
+            f"\n{self._profile_text()}\n"
+            "Ground your thinking in this persona and the faction context below before proposing actions."
+            f"\n**MarkdownContext**\n{self.base_context}\n**End of MarkdownContext**\n"
             f"Throughout the game you are acting related to the following numbered list of triplets, describing the initial state at the start of the game, end state and the gap between them:\n{self._triplet_text()}\n"
-            f"Previous actions taken by you or other actors:\n{self._history_text(history)}\n"
+            f"Previous actions taken by you or other faction representatives:\n{self._history_text(history)}\n"
             "Provide exactly three possible actions you might take next. "
             "The actions MUST be aligned with your motivations and capabilities, "
             "but at least one of them should address closing the gap between any of the above triplets."
@@ -236,7 +295,7 @@ class YamlCharacter(Character):
         self, action: str, history: List[Tuple[str, str]]
     ) -> List[int]:
         logger.info("Performing action '%s' for %s", action, self.name)
-        full_history = history + [(self.name, action)]
+        full_history = history + [(self.display_name, action)]
         context_block = (
             f"{self.base_context}\n{self._triplet_text()}\n"
             f"Action history:\n{self._history_text(full_history)}\n"

--- a/tests/fixtures/characters.yaml
+++ b/tests/fixtures/characters.yaml
@@ -1,18 +1,7 @@
-test_character:
-  MarkdownContext: |
-    Base context for test character.
-  end_states:
-    - end1
-    - end2
-    - end3
-  initial_states:
-    - initial1
-    - initial2
-    - initial3
-  gaps:
-    - severity: Small
-      explanation: gap1
-    - severity: Moderate
-      explanation: gap2
-    - severity: Large
-      explanation: gap3
+Characters:
+  - name: "Test Character"
+    faction: "test_character"
+    perks: "Detailed planner who keeps negotiators aligned"
+    weaknesses: "Struggles to prioritize when multiple crises overlap"
+    motivations: "Close policy gaps for their faction while maintaining alliances"
+    background: "Veteran mediator trained in both policy and public communications"

--- a/tests/fixtures/factions.yaml
+++ b/tests/fixtures/factions.yaml
@@ -1,0 +1,18 @@
+test_character:
+  MarkdownContext: |
+    Base context for test character.
+  end_states:
+    - end1
+    - end2
+    - end3
+  initial_states:
+    - initial1
+    - initial2
+    - initial3
+  gaps:
+    - severity: Small
+      explanation: gap1
+    - severity: Moderate
+      explanation: gap2
+    - severity: Large
+      explanation: gap3

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -14,7 +14,20 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from player_service import create_app
 from rpg.character import YamlCharacter
 
-FIXTURE_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "characters.yaml")
+CHARACTERS_FILE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "characters.yaml"
+)
+FACTIONS_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "factions.yaml")
+
+
+def _load_test_character() -> YamlCharacter:
+    with open(CHARACTERS_FILE, "r", encoding="utf-8") as fh:
+        character_payload = yaml.safe_load(fh)
+    with open(FACTIONS_FILE, "r", encoding="utf-8") as fh:
+        faction_payload = yaml.safe_load(fh)
+    profile = character_payload["Characters"][0]
+    faction_spec = faction_payload[profile["faction"]]
+    return YamlCharacter(profile["name"], faction_spec, profile)
 
 
 class PlayerServiceTest(unittest.TestCase):
@@ -36,9 +49,7 @@ class PlayerServiceTest(unittest.TestCase):
                 mock_char_genai.GenerativeModel.return_value = mock_action_model
                 mock_assess_genai.GenerativeModel.return_value = mock_assess_model
                 mock_players_genai.GenerativeModel.return_value = MagicMock()
-                with open(FIXTURE_FILE, "r", encoding="utf-8") as fh:
-                    data = yaml.safe_load(fh)
-                character = YamlCharacter("test_character", data["test_character"])
+                character = _load_test_character()
 
                 def choice_side_effect(options):
                     if options and isinstance(options[0], YamlCharacter):

--- a/web_service.py
+++ b/web_service.py
@@ -60,7 +60,7 @@ def create_app() -> Flask:
         """Display the landing page with game introduction."""
         return (
             "<h1>AI Safety Negotiation Game</h1>"
-            "<p>You are an expert negotiator with connection to all relevant actors in the AI safety world, you can convince them to propose and take actions.  your objective is to enure that ai is developed in the best interest of humanity. your goal is to keep the future human.</p>"
+            "<p>You are an expert negotiator with connections to every major faction shaping AI governance. You can persuade their key representatives to propose and take actions. Your objective is to ensure AI is developed in humanity's best interest and keep the future human.</p>"
             "<p>You have 10 turns to reach a final weighted score of 71 or higher to win.</p>"
             "<a href='/start'>Start</a>"
             f"{footer}"
@@ -95,7 +95,7 @@ def create_app() -> Flask:
 
         options = "".join(
             f'<input type="radio" name="character" value="{idx}" id="char{idx}">'
-            f'<label for="char{idx}">{char.name}</label><br>'
+            f'<label for="char{idx}">{char.display_name}</label><br>'
             for idx, char in enumerate(characters)
         )
         return (
@@ -148,8 +148,8 @@ def create_app() -> Flask:
             for idx, a in enumerate(actions)
         )
         return (
-            f"<h1>{char.name}</h1>"
-            f"<p>Which action do you want {char.name} to perform?</p>"
+            f"<h1>{char.display_name}</h1>"
+            f"<p>Which action do you want {char.display_name} to perform?</p>"
             "<form method='post' action='/perform'>"
             f"{radios}"
             f"<input type='hidden' name='character' value='{char_id}'>"


### PR DESCRIPTION
## Summary
- load faction definitions separately from new character profiles and wire the personas into prompts
- rename actor-centric state and reporting to factions, including weighted scoring and UI copy
- update loaders, services, and tests to surface faction display names and new data files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d29c6718f08333917ae3816ea47d8e