### PR TITLE
Load Markdown context from factions file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ now includes:
 
 - **CLI game (`cli_game.py`)** – play through the terminal.
 - **Flask web service (`web_service.py`)** – interact with the same mechanics via a browser.
-- **Faction definitions (`factions.yaml`)** – each YAML entry describes the
-  strategic context, goals, and gaps for a key faction in the game world.
+- **Scenario definitions (`scenarios/complete.yaml`)** – YAML mapping of
+  factions to their strategic context, goals, and gaps.
 - **Character profiles (`characters.yaml`)** – each YAML entry introduces a
   faction-aligned negotiator whose actions are generated with the model.
+- **Game configuration (`game_config.yaml`)** – sets the active scenario,
+  win threshold, and default number of rounds.
 - **Gemini API wrapper (`main.py`)** – a simple script demonstrating direct text
   generation calls.
 

--- a/factions.yaml
+++ b/factions.yaml
@@ -1,52 +1,14 @@
 Governments:
-  end_states:
-    - Impose compute caps and enforce reporting
-    - Create empowered AI oversight agencies
-    - Negotiate international agreements for verification and enforcement
-    - Shift national security framing from AGI race to Tool AI programs
-  initial_states:
-    - Political focus on economic growth and national security competition
-    - Oversight agencies limited or nonexistent
-    - Export controls exist but no international treaties on AI compute
-    - Security establishments frame AGI as strategic advantage, like nuclear weapons
-  gaps:
-    - severity: Large
-      explanation: Governments pursue economic and security competition rather than restraint
-    - severity: Large
-      explanation: Oversight agencies lack authority and speed; regulation lags industry progress
-    - severity: Critical
-      explanation: No international treaties or institutions; rivalry (e.g., US–China) intensifies
-    - severity: Critical
-      explanation: National security establishments view AGI race as winnable, opposite of the plan
   MarkdownContext: |
     ## Governments & Security Establishments
     - **Influence**: Can legislate compute caps, enforce reporting, establish oversight agencies, and negotiate international treaties. Security establishments must shift from AGI “Manhattan projects” to Tool AI “Apollo projects.”
     - **Resources/Capabilities**: Lawmaking power, export controls, intelligence and defense budgets, diplomatic channels.
-    - **Motivations**: 
+    - **Motivations**:
       - Publicly: economic growth, technological leadership, scientific progress.
       - Privately: fear of rivals gaining a decisive strategic advantage; belief that AGI could revolutionize military affairs (comparable to nuclear weapons).
     - **Interactions**: Strongly influenced by corporate lobbying; in rivalry with other governments (e.g., US–China), affecting chipmakers and regulators.
 
 Corporations:
-  end_states:
-    - Accept strict liability for dangerous systems
-    - Comply with compute oversight and hard caps
-    - Pivot business models from AGI toward Tool AI
-    - Respond to cultural and social pressure to change mission
-  initial_states:
-    - Corporations resist regulation, opposing liability frameworks such as California’s SB1047
-    - Currently maximize compute use in pursuit of AGI capabilities
-    - Business incentives favor labor-replacing AGI systems
-    - Employee dissent exists but leadership remains committed to AGI race
-  gaps:
-    - severity: Critical
-      explanation: Strong resistance to liability threatens public accountability
-    - severity: Critical
-      explanation: Corporate incentives favor AGI race; no acceptance of compute caps
-    - severity: Critical
-      explanation: Pivot to Tool AI conflicts with profit logic of automation
-    - severity: Large
-      explanation: Some cultural dissent, but weak relative to leadership and profit incentives
   MarkdownContext: |
     ## Corporations (Major Technology Companies)
     - **Influence**: Directly control AI development trajectory; could stop the AGI race and redirect toward Tool AI. Possess lobbying power to resist or shape regulation.
@@ -58,25 +20,6 @@ Corporations:
     - **Interactions**: Depend on hardware manufacturers for chips; heavily influence governments and regulators.
 
 HardwareManufacturers:
-  end_states:
-    - Embed governance features in chips (cryptographic locks, metering, geolocation)
-    - Cooperate with government oversight and reporting schemes
-    - Support global standards without loopholes
-    - Accept reduced sales in exchange for stability and safety
-  initial_states:
-    - Highly concentrated supply chain (TSMC, ASML, NVIDIA, AMD) makes oversight feasible
-    - Some export controls in place (e.g., US restrictions to China)
-    - No global harmonized standards; unilateral controls create loopholes
-    - Firms profit from maximizing demand; no incentives to restrain sales
-  gaps:
-    - severity: Moderate
-      explanation: Technical feasibility proven, but dependent on government mandates
-    - severity: Moderate
-      explanation: Partial oversight exists, but limited cooperation
-    - severity: Large
-      explanation: Global standards absent due to geopolitical rivalry
-    - severity: Large
-      explanation: Commercial incentives oppose restraint; alignment requires regulation
   MarkdownContext: |
     ## Hardware Manufacturers & Chip Supply Chain
     - **Influence**: Can embed governance features into chips, enforce compute metering, and serve as chokepoints for international verification.
@@ -87,21 +30,6 @@ HardwareManufacturers:
     - **Interactions**: Depend on government mandates for governance; affected by geopolitical rivalries between governments.
 
 Regulators:
-  end_states:
-    - Stay independent from corporate and national capture
-    - Develop clear technical standards for compute reporting and accounting
-    - Create legitimate global governance institutions
-  initial_states:
-    - Industry lobbying strongly influences rulemaking; EU AI Act exempts military AI and does not prohibit AGI
-    - Early standards like Frontier Model Forum exist but lack enforcement
-    - No global AI governance body exists; only proposals for CERN/IAEA-style institutions
-  gaps:
-    - severity: Large
-      explanation: Regulators heavily influenced by corporate lobbying and national agendas
-    - severity: Moderate
-      explanation: Groundwork exists but technical standards lack precision and enforcement
-    - severity: Critical
-      explanation: No international enforcement mechanisms; rival governments do not cooperate
   MarkdownContext: |
     ## Regulators & International Institutions
     - **Influence**: Can classify AGI as unacceptable risk, enforce tiered licensing, and potentially create international bodies like an AI IAEA.
@@ -113,21 +41,6 @@ Regulators:
     - **Interactions**: Vulnerable to corporate capture; depend on governments for legitimacy and on international cooperation for enforcement.
 
 CivilSociety:
-  end_states:
-    - Be well-informed on AGI risks and Tool AI alternatives
-    - Build broad coalitions across NGOs, labor, and media
-    - Exert democratic leverage early to influence policy
-  initial_states:
-    - Public polls show opposition to AGI but understanding of risks is shallow
-    - NGOs exist (Future of Life Institute, alignment groups) but fragmented and weak relative to corporations
-    - Institutions weak; lobbying power of corporations outweighs public preference
-  gaps:
-    - severity: Moderate
-      explanation: Public instincts align but education and awareness are lacking
-    - severity: Large
-      explanation: Coalitions fragmented; need stronger coordination
-    - severity: Large
-      explanation: Democratic pressure weak compared to corporate lobbying and declining institutional trust
   MarkdownContext: |
     ## Civil Society & the Public
     - **Influence**: Can mobilize public opinion, pressure policymakers, resist AGI inevitability narratives, and demand redistributive mechanisms like data dignity.
@@ -139,21 +52,6 @@ CivilSociety:
     - **Interactions**: Influence governments and regulators through democratic processes; need to build coalitions with scientists and media.
 
 ScientificCommunity:
-  end_states:
-    - Resist corporate funding capture
-    - Coordinate globally to prevent 'safety tourism'
-    - Engage public and policymakers with credible advocacy
-  initial_states:
-    - Many researchers absorbed by big tech labs; independent research underfunded
-    - Some collaboration among AI safety networks but fragmented
-    - Prominent researchers (Hinton, Bengio) actively warn of extinction risks
-  gaps:
-    - severity: Large
-      explanation: Corporate incentives dominate research directions
-    - severity: Moderate
-      explanation: Global coordination exists but fragmented and underpowered
-    - severity: Small
-      explanation: Advocacy growing and aligned, but not yet mainstreamed
   MarkdownContext: |
     ## Scientific & AI Research Community
     - **Influence**: Provide technical frameworks for Tool AI and safety verification, educate the public and policymakers, reframe narratives around AI safety.

--- a/game_config.yaml
+++ b/game_config.yaml
@@ -1,0 +1,4 @@
+game:
+  scenario: complete
+  win_threshold: 71
+  max_rounds: 10

--- a/rpg/config.py
+++ b/rpg/config.py
@@ -1,0 +1,81 @@
+"""Configuration loading utilities for game parameters."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import os
+from typing import Any, Dict
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GameConfig:
+    """Container for gameplay configuration values."""
+
+    scenario: str = "complete"
+    win_threshold: int = 71
+    max_rounds: int = 10
+
+
+_DEFAULT_CONFIG_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "game_config.yaml"
+)
+
+
+def _coerce_int(value: Any, fallback: int) -> int:
+    """Return ``value`` coerced to ``int`` when possible."""
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid integer value %r encountered in configuration; using %d",
+            value,
+            fallback,
+        )
+        return fallback
+
+
+def load_game_config(path: str | None = None) -> GameConfig:
+    """Load the gameplay configuration from ``path`` if available."""
+
+    config_path = path or _DEFAULT_CONFIG_PATH
+    data: Dict[str, Any] = {}
+    try:
+        with open(config_path, "r", encoding="utf-8") as fh:
+            payload = yaml.safe_load(fh) or {}
+    except FileNotFoundError:
+        logger.warning(
+            "Game configuration file %s not found; falling back to defaults",
+            config_path,
+        )
+        return GameConfig()
+    except yaml.YAMLError as exc:
+        logger.warning(
+            "Failed to parse game configuration %s: %s; using defaults",
+            config_path,
+            exc,
+        )
+        return GameConfig()
+    if isinstance(payload, dict):
+        if "game" in payload and isinstance(payload["game"], dict):
+            data = payload["game"]
+        else:
+            data = payload
+    scenario = str(data.get("scenario", "complete")).strip() or "complete"
+    win_threshold = _coerce_int(data.get("win_threshold", 71), 71)
+    max_rounds = _coerce_int(data.get("max_rounds", 10), 10)
+    return GameConfig(
+        scenario=scenario.lower(),
+        win_threshold=max(0, win_threshold),
+        max_rounds=max(1, max_rounds),
+    )
+
+
+__all__ = ["GameConfig", "load_game_config"]

--- a/rpg/game_state.py
+++ b/rpg/game_state.py
@@ -4,19 +4,23 @@
 
 from __future__ import annotations
 
-import os
 import logging
+import os
+import random
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
 from html import escape
+from typing import Dict, List, Tuple
 
-from .character import Character
+from .character import ActionOption, Character
+from .config import GameConfig, load_game_config
 
 
 logger = logging.getLogger(__name__)
 
 
-WIN_THRESHOLD = 71
+GAME_CONFIG = load_game_config()
+WIN_THRESHOLD = GAME_CONFIG.win_threshold
+MAX_ROUNDS = GAME_CONFIG.max_rounds
 
 
 @dataclass
@@ -29,6 +33,7 @@ class GameState:
     weights: Dict[str, List[int]] = field(init=False)
     how_to_win: str = field(init=False)
     faction_labels: Dict[str, str] = field(init=False)
+    config: GameConfig = field(init=False)
 
     def __post_init__(self) -> None:
         """Initialize progress tracking and load "how to win" instructions.
@@ -40,6 +45,7 @@ class GameState:
         self.progress = {}
         self.weights = {}
         self.faction_labels = {}
+        self.config = GAME_CONFIG
         for character in self.characters:
             key = character.progress_key
             if key not in self.progress:
@@ -52,18 +58,52 @@ class GameState:
         with open(win_path, "r", encoding="utf-8") as f:
             self.how_to_win = f.read()
 
-    def record_action(self, character: Character, action: str) -> None:
-        """Record an action taken by a character.
+    def record_action(
+        self, character: Character, action: ActionOption | str
+    ) -> bool:
+        """Attempt to record an action taken by a character.
+
+        The action succeeds only if a random draw from a uniform [0, 10]
+        distribution is strictly below the relevant character attribute score.
 
         Args:
             character: The faction-aligned character performing the action.
-            action: The action undertaken.
+            action: The proposed action or its textual description.
 
         Returns:
-            None.
+            ``True`` if the action is recorded as successful, ``False`` otherwise.
         """
-        logger.info("Recording action '%s' for %s", action, character.name)
-        self.history.append((character.display_name, action))
+
+        option = action if isinstance(action, ActionOption) else ActionOption(text=str(action))
+        logger.info("Evaluating action '%s' for %s", option.text, character.name)
+        attribute_name = option.related_attribute
+        attribute_score = character.attribute_score(attribute_name)
+        if attribute_name:
+            logger.info(
+                "Action related attribute for %s: %s", character.name, attribute_name
+            )
+        else:
+            logger.info(
+                "Action for %s has no related attribute; defaulting score to 0",
+                character.name,
+            )
+        logger.info(
+            "Using attribute score %s for success threshold", attribute_score
+        )
+        sampled_value = random.uniform(0, 10)
+        logger.info("Sampled %.2f from uniform[0, 10]", sampled_value)
+        success = sampled_value < attribute_score
+        if success:
+            logger.info("Action succeeded; recording in history")
+            self.history.append((character.display_name, option.text))
+        else:
+            logger.info("Action failed; recording failure entry")
+            label = attribute_name or "none"
+            failure_text = (
+                f"Failed '{option.text}' (attribute {label}: {attribute_score}, roll={sampled_value:.2f})"
+            )
+            self.history.append((character.display_name, failure_text))
+        return success
 
     def update_progress(self, scores: Dict[str, List[int]]) -> None:
         """Update progress scores for all characters.

--- a/scenarios/complete.yaml
+++ b/scenarios/complete.yaml
@@ -1,0 +1,113 @@
+Governments:
+  end_states:
+    - Impose compute caps and enforce reporting
+    - Create empowered AI oversight agencies
+    - Negotiate international agreements for verification and enforcement
+    - Shift national security framing from AGI race to Tool AI programs
+  initial_states:
+    - Political focus on economic growth and national security competition
+    - Oversight agencies limited or nonexistent
+    - Export controls exist but no international treaties on AI compute
+    - Security establishments frame AGI as strategic advantage, like nuclear weapons
+  gaps:
+    - severity: Large
+      explanation: Governments pursue economic and security competition rather than restraint
+    - severity: Large
+      explanation: Oversight agencies lack authority and speed; regulation lags industry progress
+    - severity: Critical
+      explanation: No international treaties or institutions; rivalry (e.g., US–China) intensifies
+    - severity: Critical
+      explanation: National security establishments view AGI race as winnable, opposite of the plan
+
+Corporations:
+  end_states:
+    - Accept strict liability for dangerous systems
+    - Comply with compute oversight and hard caps
+    - Pivot business models from AGI toward Tool AI
+    - Respond to cultural and social pressure to change mission
+  initial_states:
+    - Corporations resist regulation, opposing liability frameworks such as California’s SB1047
+    - Currently maximize compute use in pursuit of AGI capabilities
+    - Business incentives favor labor-replacing AGI systems
+    - Employee dissent exists but leadership remains committed to AGI race
+  gaps:
+    - severity: Critical
+      explanation: Strong resistance to liability threatens public accountability
+    - severity: Critical
+      explanation: Corporate incentives favor AGI race; no acceptance of compute caps
+    - severity: Critical
+      explanation: Pivot to Tool AI conflicts with profit logic of automation
+    - severity: Large
+      explanation: Some cultural dissent, but weak relative to leadership and profit incentives
+
+HardwareManufacturers:
+  end_states:
+    - Embed governance features in chips (cryptographic locks, metering, geolocation)
+    - Cooperate with government oversight and reporting schemes
+    - Support global standards without loopholes
+    - Accept reduced sales in exchange for stability and safety
+  initial_states:
+    - Highly concentrated supply chain (TSMC, ASML, NVIDIA, AMD) makes oversight feasible
+    - Some export controls in place (e.g., US restrictions to China)
+    - No global harmonized standards; unilateral controls create loopholes
+    - Firms profit from maximizing demand; no incentives to restrain sales
+  gaps:
+    - severity: Moderate
+      explanation: Technical feasibility proven, but dependent on government mandates
+    - severity: Moderate
+      explanation: Partial oversight exists, but limited cooperation
+    - severity: Large
+      explanation: Global standards absent due to geopolitical rivalry
+    - severity: Large
+      explanation: Commercial incentives oppose restraint; alignment requires regulation
+
+Regulators:
+  end_states:
+    - Stay independent from corporate and national capture
+    - Develop clear technical standards for compute reporting and accounting
+    - Create legitimate global governance institutions
+  initial_states:
+    - Industry lobbying strongly influences rulemaking; EU AI Act exempts military AI and does not prohibit AGI
+    - Early standards like Frontier Model Forum exist but lack enforcement
+    - No global AI governance body exists; only proposals for CERN/IAEA-style institutions
+  gaps:
+    - severity: Large
+      explanation: Regulators heavily influenced by corporate lobbying and national agendas
+    - severity: Moderate
+      explanation: Groundwork exists but technical standards lack precision and enforcement
+    - severity: Critical
+      explanation: No international enforcement mechanisms; rival governments do not cooperate
+
+CivilSociety:
+  end_states:
+    - Be well-informed on AGI risks and Tool AI alternatives
+    - Build broad coalitions across NGOs, labor, and media
+    - Exert democratic leverage early to influence policy
+  initial_states:
+    - Public polls show opposition to AGI but understanding of risks is shallow
+    - NGOs exist (Future of Life Institute, alignment groups) but fragmented and weak relative to corporations
+    - Institutions weak; lobbying power of corporations outweighs public preference
+  gaps:
+    - severity: Moderate
+      explanation: Public instincts align but education and awareness are lacking
+    - severity: Large
+      explanation: Coalitions fragmented; need stronger coordination
+    - severity: Large
+      explanation: Democratic pressure weak compared to corporate lobbying and declining institutional trust
+
+ScientificCommunity:
+  end_states:
+    - Resist corporate funding capture
+    - Coordinate globally to prevent 'safety tourism'
+    - Engage public and policymakers with credible advocacy
+  initial_states:
+    - Many researchers absorbed by big tech labs; independent research underfunded
+    - Some collaboration among AI safety networks but fragmented
+    - Prominent researchers (Hinton, Bengio) actively warn of extinction risks
+  gaps:
+    - severity: Large
+      explanation: Corporate incentives dominate research directions
+    - severity: Moderate
+      explanation: Global coordination exists but fragmented and underpowered
+    - severity: Small
+      explanation: Advocacy growing and aligned, but not yet mainstreamed

--- a/tests/fixtures/characters.yaml
+++ b/tests/fixtures/characters.yaml
@@ -1,6 +1,10 @@
 Characters:
   - name: "Test Character"
     faction: "test_character"
+    leadership: "6"
+    technology: "5"
+    policy: "4"
+    network: "3"
     perks: "Detailed planner who keeps negotiators aligned"
     weaknesses: "Struggles to prioritize when multiple crises overlap"
     motivations: "Close policy gaps for their faction while maintaining alliances"

--- a/tests/fixtures/factions.yaml
+++ b/tests/fixtures/factions.yaml
@@ -1,18 +1,3 @@
 test_character:
   MarkdownContext: |
     Base context for test character.
-  end_states:
-    - end1
-    - end2
-    - end3
-  initial_states:
-    - initial1
-    - initial2
-    - initial3
-  gaps:
-    - severity: Small
-      explanation: gap1
-    - severity: Moderate
-      explanation: gap2
-    - severity: Large
-      explanation: gap3

--- a/tests/fixtures/scenarios/complete.yaml
+++ b/tests/fixtures/scenarios/complete.yaml
@@ -1,0 +1,16 @@
+test_character:
+  end_states:
+    - end1
+    - end2
+    - end3
+  initial_states:
+    - initial1
+    - initial2
+    - initial3
+  gaps:
+    - severity: Small
+      explanation: gap1
+    - severity: Moderate
+      explanation: gap2
+    - severity: Large
+      explanation: gap3

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import json
 import os
 import sys
 import unittest
@@ -12,18 +13,20 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from players import RandomPlayer, GeminiWinPlayer, GeminiGovCorpPlayer
 from rpg.assessment_agent import AssessmentAgent
 from rpg.game_state import GameState
-from rpg.character import YamlCharacter
+from rpg.character import ActionOption, YamlCharacter
 
 CHARACTERS_FILE = os.path.join(
     os.path.dirname(__file__), "fixtures", "characters.yaml"
 )
-FACTIONS_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "factions.yaml")
+SCENARIO_FILE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "scenarios", "complete.yaml"
+)
 
 
 def _load_test_character() -> YamlCharacter:
     with open(CHARACTERS_FILE, "r", encoding="utf-8") as fh:
         character_payload = yaml.safe_load(fh)
-    with open(FACTIONS_FILE, "r", encoding="utf-8") as fh:
+    with open(SCENARIO_FILE, "r", encoding="utf-8") as fh:
         faction_payload = yaml.safe_load(fh)
     profile = character_payload["Characters"][0]
     faction_spec = faction_payload[profile["faction"]]
@@ -34,11 +37,32 @@ class PlayerTests(unittest.TestCase):
     @patch("players.random.choice")
     @patch("rpg.assessment_agent.genai")
     @patch("rpg.character.genai")
-    def test_random_player_turn(self, mock_char_genai, mock_assess_genai, mock_choice):
+    @patch("rpg.game_state.random.uniform", return_value=0)
+    def test_random_player_turn(
+        self, mock_uniform, mock_char_genai, mock_assess_genai, mock_choice
+    ):
         mock_action_model = MagicMock()
         mock_assess_model = MagicMock()
         mock_action_model.generate_content.return_value = MagicMock(
-            text="1. A\n2. B\n3. C"
+            text=json.dumps(
+                [
+                    {
+                        "text": "A",
+                        "related-triplet": 1,
+                        "related-attribute": "leadership",
+                    },
+                    {
+                        "text": "B",
+                        "related-triplet": "None",
+                        "related-attribute": "technology",
+                    },
+                    {
+                        "text": "C",
+                        "related-triplet": "None",
+                        "related-attribute": "policy",
+                    },
+                ]
+            )
         )
         mock_assess_model.generate_content.return_value = MagicMock(
             text="10\n20\n30"
@@ -48,7 +72,12 @@ class PlayerTests(unittest.TestCase):
         char = _load_test_character()
         state = GameState([char])
         assessor = AssessmentAgent()
-        mock_choice.side_effect = [char, "A"]
+        def choice_side_effect(options):
+            if options and isinstance(options[0], YamlCharacter):
+                return char
+            return options[0]
+
+        mock_choice.side_effect = choice_side_effect
         player = RandomPlayer()
         player.take_turn(state, assessor)
         self.assertEqual(
@@ -67,7 +96,7 @@ class PlayerTests(unittest.TestCase):
         char = _load_test_character()
         state = GameState([char])
         player = GeminiWinPlayer()
-        actions = ["A", "B", "C"]
+        actions = [ActionOption("A"), ActionOption("B"), ActionOption("C")]
         player.select_action(char, actions, state)
         prompt = mock_model.generate_content.call_args[0][0]
         self.assertIn(state.how_to_win.split()[0], prompt)
@@ -84,7 +113,7 @@ class PlayerTests(unittest.TestCase):
         gov_ctx = corp_ctx = "CTX"
         player = GeminiGovCorpPlayer(gov_ctx, corp_ctx)
         state = GameState([char])
-        actions = ["A", "B", "C"]
+        actions = [ActionOption("A"), ActionOption("B"), ActionOption("C")]
         player.select_action(char, actions, state)
         prompt = mock_model.generate_content.call_args[0][0]
         self.assertIn("CTX", prompt)


### PR DESCRIPTION
## Summary
- reintroduce Markdown context descriptions in `factions.yaml` and trim `scenarios/complete.yaml` to triplet data
- teach `load_characters` to merge scenario triplets with Markdown context payloads so characters retain narrative prompts
- refresh fixtures and tests to reflect the split files and cover the merged loader behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2de0d55d48333bdf845eb932a9a02