### PR TITLE
Load credibility matrix from JSON and unify adjustments

### DIFF
--- a/rpg/credibility.py
+++ b/rpg/credibility.py
@@ -1,0 +1,240 @@
+"""Utilities for managing inter-faction credibility relationships."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_CREDIBILITY = 50
+DIAGONAL_CREDIBILITY = 100
+CREDIBILITY_REWARD = 20
+CREDIBILITY_PENALTY = 20
+
+_FALLBACK_DATA: Dict[str, object] = {
+    "factions": [
+        "Governments",
+        "Corporations",
+        "HardwareManufacturers",
+        "Regulators",
+        "CivilSociety",
+        "ScientificCommunity",
+    ],
+    "credibility": {
+        "Governments": {
+            "Governments": 100,
+            "Corporations": 35,
+            "HardwareManufacturers": 70,
+            "Regulators": 65,
+            "CivilSociety": 55,
+            "ScientificCommunity": 75,
+        },
+        "Corporations": {
+            "Governments": 45,
+            "Corporations": 100,
+            "HardwareManufacturers": 85,
+            "Regulators": 30,
+            "CivilSociety": 20,
+            "ScientificCommunity": 55,
+        },
+        "HardwareManufacturers": {
+            "Governments": 70,
+            "Corporations": 80,
+            "HardwareManufacturers": 100,
+            "Regulators": 55,
+            "CivilSociety": 35,
+            "ScientificCommunity": 60,
+        },
+        "Regulators": {
+            "Governments": 75,
+            "Corporations": 25,
+            "HardwareManufacturers": 65,
+            "Regulators": 100,
+            "CivilSociety": 70,
+            "ScientificCommunity": 80,
+        },
+        "CivilSociety": {
+            "Governments": 50,
+            "Corporations": 15,
+            "HardwareManufacturers": 30,
+            "Regulators": 75,
+            "CivilSociety": 100,
+            "ScientificCommunity": 85,
+        },
+        "ScientificCommunity": {
+            "Governments": 65,
+            "Corporations": 35,
+            "HardwareManufacturers": 55,
+            "Regulators": 85,
+            "CivilSociety": 80,
+            "ScientificCommunity": 100,
+        },
+    },
+}
+
+_MATRIX_FILE = Path(__file__).with_name("credibility_matrix.json")
+
+
+def _safe_int(value: object, default: int = DEFAULT_BASE_CREDIBILITY) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _load_initial_data() -> Tuple[List[str], Dict[str, Dict[str, int]]]:
+    factions = [str(f) for f in _FALLBACK_DATA["factions"]]  # type: ignore[list-item]
+    credibility = {
+        source: {target: _safe_int(value) for target, value in targets.items()}
+        for source, targets in (
+            _FALLBACK_DATA["credibility"].items()  # type: ignore[union-attr]
+        )
+    }
+    try:
+        with _MATRIX_FILE.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        return factions, credibility
+    except json.JSONDecodeError as exc:  # pragma: no cover - guarded fallback
+        logger.warning("Failed to parse credibility matrix JSON: %s", exc)
+        return factions, credibility
+    if not isinstance(data, dict):
+        logger.warning("Credibility matrix JSON root must be an object; using fallback")
+        return factions, credibility
+    file_factions = data.get("factions")
+    file_matrix = data.get("credibility")
+    if isinstance(file_factions, list):
+        factions = [str(item) for item in file_factions]
+    else:
+        logger.warning("Missing 'factions' list in credibility matrix; using fallback order")
+    if isinstance(file_matrix, dict):
+        parsed: Dict[str, Dict[str, int]] = {}
+        for source, targets in file_matrix.items():
+            if not isinstance(targets, dict):
+                continue
+            parsed[str(source)] = {
+                str(target): _safe_int(value)
+                for target, value in targets.items()
+            }
+        if parsed:
+            credibility = parsed
+    else:
+        logger.warning("Missing 'credibility' mapping in matrix; using fallback values")
+    return factions, credibility
+
+
+DEFAULT_FACTIONS, _DEFAULT_MATRIX = _load_initial_data()
+
+
+def _clamp(value: int) -> int:
+    return max(0, min(100, value))
+
+
+def _coerce(value: object, default: int) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _ordered_union(primary: Iterable[str], secondary: Iterable[str]) -> List[str]:
+    seen = set()
+    order: List[str] = []
+    for collection in (primary, secondary):
+        for item in collection:
+            if item not in seen:
+                seen.add(item)
+                order.append(item)
+    return order
+
+
+@dataclass
+class CredibilityMatrix:
+    """Track directed credibility values between factions."""
+
+    _values: Dict[str, Dict[str, int]] = field(init=False, repr=False)
+    _order: List[str] = field(init=False, repr=False)
+
+    def __init__(self, values: Dict[str, Dict[str, int]] | None = None) -> None:
+        base = values or _DEFAULT_MATRIX
+        all_sources = _ordered_union(DEFAULT_FACTIONS, base.keys())
+        all_targets = _ordered_union(DEFAULT_FACTIONS, {
+            target for mapping in base.values() for target in mapping.keys()
+        })
+        factions = _ordered_union(all_sources, all_targets)
+        self._order = list(factions)
+        self._values = {}
+        for source in factions:
+            row: Dict[str, int] = {}
+            provided_row = base.get(source, {})
+            for target in factions:
+                if source == target:
+                    row[target] = DIAGONAL_CREDIBILITY
+                else:
+                    raw_value = provided_row.get(target, DEFAULT_BASE_CREDIBILITY)
+                    row[target] = _clamp(_coerce(raw_value, DEFAULT_BASE_CREDIBILITY))
+            self._values[source] = row
+
+    def ensure_faction(self, faction: str | None) -> None:
+        """Guarantee that ``faction`` is present in the matrix."""
+
+        if not faction:
+            return
+        if faction not in self._order:
+            self._order.append(faction)
+        if faction not in self._values:
+            self._values[faction] = {}
+        for source in self._order:
+            row = self._values.setdefault(source, {})
+            for target in self._order:
+                if source == target:
+                    row[target] = DIAGONAL_CREDIBILITY
+                else:
+                    row.setdefault(target, DEFAULT_BASE_CREDIBILITY)
+
+    def adjust(self, source: str | None, target: str | None, delta: int) -> None:
+        """Modify credibility from ``source`` to ``target`` by ``delta`` within [0, 100]."""
+
+        if not source or not target or delta == 0:
+            return
+        self.ensure_faction(source)
+        self.ensure_faction(target)
+        if source == target:
+            return
+        row = self._values[source]
+        row[target] = _clamp(row[target] + delta)
+
+    def value(self, source: str, target: str) -> int:
+        """Return the credibility value for ``source`` as viewed by ``target``."""
+
+        self.ensure_faction(source)
+        self.ensure_faction(target)
+        return self._values[source][target]
+
+    def snapshot(self) -> Dict[str, Dict[str, int]]:
+        """Return a deep copy of the current matrix values."""
+
+        return {source: dict(targets) for source, targets in self._values.items()}
+
+    @property
+    def factions(self) -> List[str]:
+        """Return the list of known factions in insertion order."""
+
+        return list(self._order)
+
+
+__all__ = [
+    "CredibilityMatrix",
+    "DEFAULT_FACTIONS",
+    "DEFAULT_BASE_CREDIBILITY",
+    "DIAGONAL_CREDIBILITY",
+    "CREDIBILITY_REWARD",
+    "CREDIBILITY_PENALTY",
+]

--- a/rpg/credibility_matrix.json
+++ b/rpg/credibility_matrix.json
@@ -1,0 +1,60 @@
+{
+  "factions": [
+    "Governments",
+    "Corporations",
+    "HardwareManufacturers",
+    "Regulators",
+    "CivilSociety",
+    "ScientificCommunity"
+  ],
+  "credibility": {
+    "Governments": {
+      "Governments": 100,
+      "Corporations": 35,
+      "HardwareManufacturers": 70,
+      "Regulators": 65,
+      "CivilSociety": 55,
+      "ScientificCommunity": 75
+    },
+    "Corporations": {
+      "Governments": 45,
+      "Corporations": 100,
+      "HardwareManufacturers": 85,
+      "Regulators": 30,
+      "CivilSociety": 20,
+      "ScientificCommunity": 55
+    },
+    "HardwareManufacturers": {
+      "Governments": 70,
+      "Corporations": 80,
+      "HardwareManufacturers": 100,
+      "Regulators": 55,
+      "CivilSociety": 35,
+      "ScientificCommunity": 60
+    },
+    "Regulators": {
+      "Governments": 75,
+      "Corporations": 25,
+      "HardwareManufacturers": 65,
+      "Regulators": 100,
+      "CivilSociety": 70,
+      "ScientificCommunity": 80
+    },
+    "CivilSociety": {
+      "Governments": 50,
+      "Corporations": 15,
+      "HardwareManufacturers": 30,
+      "Regulators": 75,
+      "CivilSociety": 100,
+      "ScientificCommunity": 85
+    },
+    "ScientificCommunity": {
+      "Governments": 65,
+      "Corporations": 35,
+      "HardwareManufacturers": 55,
+      "Regulators": 85,
+      "CivilSociety": 80,
+      "ScientificCommunity": 100
+    }
+  }
+}

--- a/tests/test_credibility.py
+++ b/tests/test_credibility.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from rpg.character import ActionOption
+from rpg.game_state import GameState
+
+
+class DummyCharacter:
+    def __init__(self, name: str, faction: str) -> None:
+        self.name = name
+        self.faction = faction
+        self.progress_key = faction
+        self.progress_label = faction
+        self.display_name = name
+        self.triplets = [("initial", "end", {"severity": "Small"})]
+        self.weights = [1]
+
+    def attribute_score(self, attribute):
+        return 10
+
+    def generate_actions(self, history):  # pragma: no cover - not used
+        return []
+
+    def perform_action(self, action, history):  # pragma: no cover - not used
+        return [0]
+
+
+class CredibilityMatrixTests(unittest.TestCase):
+    @patch("rpg.game_state.random.uniform", return_value=0)
+    def test_record_action_rewards_targets(self, mock_uniform):
+        character = DummyCharacter("Alice", "Governments")
+        state = GameState([character])
+        initial = state.credibility.value("Governments", "Regulators")
+        action = ActionOption(text="Coordinate with regulators", related_triplet=None)
+        state.record_action(character, action, targets=["Regulators"])
+        updated = state.credibility.value("Governments", "Regulators")
+        self.assertEqual(updated, min(100, initial + 20))
+
+    @patch("rpg.game_state.random.uniform", return_value=0)
+    def test_record_action_penalises_targets_with_triplet(self, mock_uniform):
+        character = DummyCharacter("Alice", "Governments")
+        state = GameState([character])
+        initial = state.credibility.value("Governments", "Regulators")
+        action = ActionOption(text="Enforce compute caps", related_triplet=1)
+        state.record_action(character, action, targets=["Regulators"])
+        updated = state.credibility.value("Governments", "Regulators")
+        self.assertEqual(updated, max(0, initial - 20))
+
+    @patch("rpg.game_state.random.uniform", return_value=0)
+    def test_record_action_without_targets_applies_penalty(self, mock_uniform):
+        character = DummyCharacter("Alice", "Governments")
+        state = GameState([character])
+        initial = state.credibility.value("Governments", "Corporations")
+        action = ActionOption(text="Limit compute", related_triplet=1)
+        state.record_action(character, action)
+        updated = state.credibility.value("Governments", "Corporations")
+        self.assertEqual(updated, max(0, initial - 20))
+
+    @patch("rpg.game_state.random.uniform", return_value=0)
+    def test_unknown_faction_initialises_defaults(self, mock_uniform):
+        outsider = DummyCharacter("Bob", "NewFaction")
+        state = GameState([outsider])
+        action = ActionOption(text="Build bridges", related_triplet=None)
+        state.record_action(outsider, action, targets=["Governments"])
+        self.assertEqual(state.credibility.value("NewFaction", "Governments"), 70)
+        self.assertEqual(state.credibility.value("Governments", "NewFaction"), 50)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- load the starting credibility matrix from a JSON file with the provided values
- adjust credibility updates so all factions spend on related triplet actions and gain on other successes
- expand credibility tests to cover default penalties and the new behaviour

## Testing
- pytest tests/test_credibility.py

------
https://chatgpt.com/codex/tasks/task_e_68e82e628e2c8333bafa66b301eedb1c