### PR TITLE
Ensure player responses stay chat-only and consolidate NPC actions

### DIFF
--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -176,9 +176,10 @@ class YamlCharacterTest(unittest.TestCase):
             display_name="NPC", faction="Allies", triplets=[(1, 2, 3)]
         )
         options = player.generate_responses([], [], partner)
-        self.assertEqual(len(options), 2)
-        self.assertIsInstance(options[0], ResponseOption)
-        self.assertEqual(options[1].type, "action")
+        self.assertEqual(len(options), 3)
+        self.assertTrue(all(option.type == "chat" for option in options))
+        texts = {option.text for option in options}
+        self.assertEqual(len(texts), 3)
 
     @patch("rpg.character.genai")
     def test_load_characters_merges_markdown_context(self, mock_char_genai):

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock, patch
+
+from rpg.game_state import GameState
+from rpg.character import ResponseOption
+
+
+class DummyCharacter:
+    def __init__(self) -> None:
+        self.name = "Ally"
+        self.display_name = "Ally Representative"
+        self.faction = "Allies"
+        self.progress_key = "Allies"
+        self.progress_label = "Allies"
+        self.triplets = [("init", "end", "gap")]
+        self.weights = [1]
+
+    def attribute_score(self, _attribute: str | None) -> int:
+        return 0
+
+
+@patch("rpg.character.genai")
+def test_log_npc_responses_records_single_entry(mock_genai):
+    mock_model = MagicMock()
+    mock_model.generate_content.return_value = MagicMock(text="[]")
+    mock_genai.GenerativeModel.return_value = mock_model
+
+    character = DummyCharacter()
+    state = GameState([character])
+    action_option = ResponseOption(
+        text="Build community shelters",
+        type="action",
+        related_triplet=1,
+        related_attribute="network",
+    )
+    chat_option = ResponseOption(text="We can mobilise volunteers.", type="chat")
+
+    entries = state.log_npc_responses(character, [action_option, chat_option])
+
+    assert len(entries) == 1
+    history = state.conversation_history(character)
+    assert len(history) == 1
+    assert history[0].text == chat_option.text
+    stored_actions = state.available_npc_actions(character)
+    assert any(option.text == action_option.text for option in stored_actions)


### PR DESCRIPTION
## Summary
- Force the player conversation model to return exactly three chat-only responses, reclassifying accidental action suggestions and expanding action payload logging details.
- Record only a single NPC utterance per turn while keeping all proposed actions available to the player, and surface those actions alongside the player's choices in the CLI.
- Add coverage for the new NPC logging behaviour and update existing tests to match the revised player response expectations.

## Testing
- pytest --maxfail=1 -k "not test_genai_example"

------
https://chatgpt.com/codex/tasks/task_e_68e99309d9b4833383a4d6b68e5eeb5c