### PR TITLE
Add player persona data, rerolls, and responsive web layout

### DIFF
--- a/rpg/player_character.yaml
+++ b/rpg/player_character.yaml
@@ -1,0 +1,11 @@
+Characters:
+  - name: "Jordan Ellis"
+    faction: "CivilSociety"
+    leadership: "6"
+    technology: "3"
+    policy: "7"
+    network: "8"
+    perks: "Trusted civic organizer who can translate grassroots energy into policy-ready campaigns"
+    weaknesses: "Limited technical depth; must rely on expert allies for complex tooling decisions"
+    motivations: "Mobilize broad democratic coalitions to lock in enforceable AI guardrails and equitable Tool AI investments"
+    background: "Former journalist turned coalition-builder who has coordinated cross-movement actions on privacy, labor, and tech accountability."

--- a/tests/test_credibility.py
+++ b/tests/test_credibility.py
@@ -39,7 +39,7 @@ class CredibilityMatrixTests(unittest.TestCase):
         )
         state.record_action(character, action, targets=["Regulators"])
         updated_player = state.credibility.value(PLAYER_FACTION, "Regulators")
-        self.assertEqual(updated_player, min(100, initial_player + 20))
+        self.assertEqual(updated_player, min(100, initial_player + 10))
 
     @patch("rpg.character.genai")
     @patch("rpg.game_state.random.uniform", return_value=0)
@@ -55,7 +55,7 @@ class CredibilityMatrixTests(unittest.TestCase):
         )
         state.record_action(character, action, targets=["Regulators"])
         updated_player = state.credibility.value(PLAYER_FACTION, "Regulators")
-        self.assertEqual(updated_player, max(0, initial_player - 20))
+        self.assertEqual(updated_player, max(0, initial_player - 30))
 
     @patch("rpg.character.genai")
     @patch("rpg.game_state.random.uniform", return_value=0)
@@ -69,7 +69,7 @@ class CredibilityMatrixTests(unittest.TestCase):
         action = ResponseOption(text="Limit compute", type="action", related_triplet=1)
         state.record_action(character, action)
         updated_player = state.credibility.value(PLAYER_FACTION, "Governments")
-        self.assertEqual(updated_player, max(0, initial_player - 20))
+        self.assertEqual(updated_player, max(0, initial_player - 30))
 
     @patch("rpg.character.genai")
     @patch("rpg.game_state.random.uniform", return_value=0)
@@ -79,7 +79,7 @@ class CredibilityMatrixTests(unittest.TestCase):
         state = GameState([outsider])
         action = ResponseOption(text="Build bridges", type="action", related_triplet=None)
         state.record_action(outsider, action, targets=["Governments"])
-        self.assertEqual(state.credibility.value(PLAYER_FACTION, "Governments"), 70)
+        self.assertEqual(state.credibility.value(PLAYER_FACTION, "Governments"), 60)
         self.assertEqual(state.credibility.value("Governments", "NewFaction"), 50)
 
 


### PR DESCRIPTION
## Summary
- load the human player persona from a new Civil Society YAML profile and feed its context into prompt generation
- overhaul action resolution to compare player attributes, support rerolls with escalating credibility adjustments, and expose the options via CLI and web flows
- redesign the conversation page into three responsive panels with dedicated reroll handling and update credibility tests for the new calculations

## Testing
- pytest *(fails: missing PyYAML dependency in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ead3262c5c8333a1f32bf311d3be1a