### PR TITLE
Improve async response handling and action display

### DIFF
--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -119,12 +119,10 @@ class WebServiceTest(unittest.TestCase):
             convo_resp = client.get("/actions", query_string={"character": "0"})
             convo_page = convo_resp.data.decode()
             self.assertEqual(convo_resp.status_code, 200)
-            self.assertIn(f"<h1>{character.display_name}</h1>", convo_page)
+            self.assertIn("Conversation with", convo_page)
+            self.assertIn(character.display_name, convo_page)
             self.assertIn("No conversation yet", convo_page)
-            starter_text = (
-                "It's good to connect, "
-                f"{character.name}. What's top of mind for you today?"
-            )
+            starter_text = "What worries you most?"
             self.assertIn(starter_text, convo_page)
 
             chat_payload = json.dumps(
@@ -136,9 +134,9 @@ class WebServiceTest(unittest.TestCase):
                 follow_redirects=True,
             )
             follow_page = follow_resp.data.decode()
-            self.assertIn("Coordinate oversight teams", follow_page)
-            self.assertIn("<em>(action)</em>", follow_page)
-            self.assertIn("<strong>Action:</strong>", follow_page)
+            self.assertIn("<em>(chat)</em>", follow_page)
+            self.assertIn("Action 1 [Leadership]", follow_page)
+            self.assertIn("title='Coordinate oversight teams'", follow_page)
 
             action_option = ResponseOption(
                 text=npc_action_text,


### PR DESCRIPTION
## Summary
- load player reply options asynchronously per conversation turn and render the conversation with a loading state instead of blocking
- surface every NPC action as a selectable option with concise labels while preserving the full text via tooltips, and reuse generated NPC actions across turns
- rely on generated starter replies for the player, capturing fallback templates only as needed, and extend tests to cover the new flow

## Testing
- pytest tests/test_web_service.py

------
https://chatgpt.com/codex/tasks/task_e_68ec1ff7e0f08333b25724de61cb0eed