### PR TITLE
Improve action labeling and credibility UI

### DIFF
--- a/rpg/character.py
+++ b/rpg/character.py
@@ -491,13 +491,17 @@ class PlayerCharacter(Character):
             else:
                 self.weights.append(1)
 
+        faction_descriptor = re.sub(r"(?<!^)(?=[A-Z])", " ", faction).strip() or faction
+        faction_lower = faction_descriptor.lower()
         persona_lines = [
-            f"You are {name}, a civil society strategist navigating AI governance negotiations.",
+            f"You are {name}, a {faction_lower} strategist navigating AI governance negotiations.",
             str(profile.get("background", "")),
             "Use your coalition-building strengths to elicit concrete commitments from partners.",
         ]
         if base_context:
-            persona_lines.append("Ground yourself in the detailed civil society context provided.")
+            persona_lines.append(
+                f"Ground yourself in the detailed {faction_lower} context provided."
+            )
         persona = " ".join(line for line in persona_lines if line)
 
         super().__init__(
@@ -513,6 +517,7 @@ class PlayerCharacter(Character):
         self.profile = profile
         self.base_context = base_context
         self._attribute_scores: dict[str, int] = {}
+        self._faction_descriptor = faction_descriptor
         for attr in ("leadership", "technology", "policy", "network"):
             raw_value = profile.get(attr)
             if raw_value is None and attr.capitalize() in profile:
@@ -528,9 +533,9 @@ class PlayerCharacter(Character):
             return 0
         return self._attribute_scores.get(attribute.lower(), 0)
 
-    def _civil_society_context(self) -> str:
+    def _faction_context(self) -> str:
         if not self.base_context:
-            return "No additional civil society context provided."
+            return f"No additional {self._faction_descriptor.lower()} context provided."
         return self.base_context
 
     def generate_responses(
@@ -545,13 +550,13 @@ class PlayerCharacter(Character):
             f"{key.title()}: {value}" for key, value in self._attribute_scores.items()
         )
         base_prompt = (
-            "You are the civil society player in the 'Keep the Future Human' survival RPG. "
+            f"You are the {self._faction_descriptor.lower()} player in the 'Keep the Future Human' survival RPG. "
             f"You are speaking with {partner_label} from the {partner.faction or 'independent'} faction. "
             "Draw on your coalition strengths to encourage them to state concrete actions they can take. "
             "Offer exactly three concise 'chat' responses that keep the conversation moving without proposing actions yourself."
         )
         context_prompt = (
-            f"\n### Your Civil Society Context\n{self._civil_society_context()}\n"
+            f"\n### Your {self._faction_descriptor} Context\n{self._faction_context()}\n"
             if self.base_context
             else ""
         )

--- a/rpg/credibility.py
+++ b/rpg/credibility.py
@@ -224,12 +224,6 @@ class CredibilityMatrix:
         )
         self.ensure_faction(source)
         self.ensure_faction(target)
-        if source == target:
-            logger.debug(
-                "Skipping credibility adjustment because source and target are identical: %s",
-                source,
-            )
-            return
         row = self._values[source]
         current_value = row[target]
         logger.debug(

--- a/tests/test_credibility.py
+++ b/tests/test_credibility.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from rpg.character import ResponseOption
-from rpg.game_state import PLAYER_FACTION, GameState
+from rpg.game_state import GameState
 
 
 class DummyCharacter:
@@ -33,12 +33,13 @@ class CredibilityMatrixTests(unittest.TestCase):
         mock_genai.GenerativeModel.return_value = MagicMock()
         character = DummyCharacter("Alice", "Governments")
         state = GameState([character])
-        initial_player = state.credibility.value(PLAYER_FACTION, "Regulators")
+        player_faction = state.player_faction
+        initial_player = state.credibility.value(player_faction, "Regulators")
         action = ResponseOption(
             text="Coordinate with regulators", type="action", related_triplet=None
         )
         state.record_action(character, action, targets=["Regulators"])
-        updated_player = state.credibility.value(PLAYER_FACTION, "Regulators")
+        updated_player = state.credibility.value(player_faction, "Regulators")
         self.assertEqual(updated_player, min(100, initial_player + 10))
 
     @patch("rpg.character.genai")
@@ -49,12 +50,13 @@ class CredibilityMatrixTests(unittest.TestCase):
         mock_genai.GenerativeModel.return_value = MagicMock()
         character = DummyCharacter("Alice", "Governments")
         state = GameState([character])
-        initial_player = state.credibility.value(PLAYER_FACTION, "Regulators")
+        player_faction = state.player_faction
+        initial_player = state.credibility.value(player_faction, "Regulators")
         action = ResponseOption(
             text="Enforce compute caps", type="action", related_triplet=1
         )
         state.record_action(character, action, targets=["Regulators"])
-        updated_player = state.credibility.value(PLAYER_FACTION, "Regulators")
+        updated_player = state.credibility.value(player_faction, "Regulators")
         self.assertEqual(updated_player, max(0, initial_player - 30))
 
     @patch("rpg.character.genai")
@@ -65,10 +67,11 @@ class CredibilityMatrixTests(unittest.TestCase):
         mock_genai.GenerativeModel.return_value = MagicMock()
         character = DummyCharacter("Alice", "Governments")
         state = GameState([character])
-        initial_player = state.credibility.value(PLAYER_FACTION, "Governments")
+        player_faction = state.player_faction
+        initial_player = state.credibility.value(player_faction, "Governments")
         action = ResponseOption(text="Limit compute", type="action", related_triplet=1)
         state.record_action(character, action)
-        updated_player = state.credibility.value(PLAYER_FACTION, "Governments")
+        updated_player = state.credibility.value(player_faction, "Governments")
         self.assertEqual(updated_player, max(0, initial_player - 30))
 
     @patch("rpg.character.genai")
@@ -79,7 +82,8 @@ class CredibilityMatrixTests(unittest.TestCase):
         state = GameState([outsider])
         action = ResponseOption(text="Build bridges", type="action", related_triplet=None)
         state.record_action(outsider, action, targets=["Governments"])
-        self.assertEqual(state.credibility.value(PLAYER_FACTION, "Governments"), 60)
+        player_faction = state.player_faction
+        self.assertEqual(state.credibility.value(player_faction, "Governments"), 60)
         self.assertEqual(state.credibility.value("Governments", "NewFaction"), 50)
 
 


### PR DESCRIPTION
## Summary
- track action labels and original response options in game state so conversations log labels and credibility costs apply even within the player faction
- refresh the web UI to show per-character credibility, relabel NPC proposals, streamline failure reroll controls, and flush NPC action lists after execution
- derive the player persona’s faction name from YAML and adjust tests for the dynamic player faction lookup

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68ec9cd06ba48333816604a1053a4e62