### PR TITLE
Fix clearing of pending options when parallelism enabled

### DIFF
--- a/web_service.py
+++ b/web_service.py
@@ -761,7 +761,7 @@ def create_app() -> Flask:
         else:
             pending_player_choices.pop(char_id, None)
             _clear_pending_npc_entries(char_id)
-            _clear_player_option_entries(char_id)
+            _clear_player_option_entries(char_id, keep_length=len(conversation))
 
         options, loading = _resolve_player_options(
             char_id, history, conversation, character, player


### PR DESCRIPTION
## Summary
- ensure pending player option entries for the current conversation are preserved when resetting caches
- prevents repeated background thread launches and loading loops when parallel option generation is enabled

## Testing
- pytest *(fails: missing dependency: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68eca4b5ddb88333b3cc79a5a055a769