### PR TITLE
Limit NPC action offerings and sanitize fallback chat output

### DIFF
--- a/rpg/character.py
+++ b/rpg/character.py
@@ -282,11 +282,12 @@ class Character(ABC):
                 responses.append(option)
         if not responses:
             lines = [line.strip() for line in response_text.splitlines() if line.strip()]
-            if lines:
+            cleaned_lines = [line for line in lines if not line.startswith("```")]
+            if cleaned_lines:
                 logger.info(
                     "Falling back to line-by-line responses for %s", self.name
                 )
-            for line in lines:
+            for line in cleaned_lines:
                 responses.append(ResponseOption(text=line, type="chat"))
         return responses[:3]
 

--- a/rpg/game_state.py
+++ b/rpg/game_state.py
@@ -148,16 +148,11 @@ class GameState:
         chat_candidate: ResponseOption | None = None
         fallback_option: ResponseOption | None = None
         for option in responses:
-            if option.is_action:
-                action_bucket.setdefault(option.text, option)
             if option.is_action and action_candidate is None:
                 action_candidate = option
             elif not option.is_action and chat_candidate is None:
                 chat_candidate = option
             fallback_option = fallback_option or option
-
-        if action_bucket:
-            self._refresh_action_labels(key)
 
         selected_option = action_candidate or chat_candidate or fallback_option
         if selected_option is not None:
@@ -173,11 +168,7 @@ class GameState:
             )
             history.append(entry)
             entries.append(entry)
-        # Store any additional unique action proposals for later execution.
-        for option in responses:
-            if option.is_action:
-                action_bucket.setdefault(option.text, option)
-        if action_bucket:
+        if selected_option is None and action_bucket:
             self._refresh_action_labels(key)
         logger.debug(
             "Logged %d NPC responses for %s (stored %d actions)",

--- a/tests/test_character_fallback.py
+++ b/tests/test_character_fallback.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from rpg.character import YamlCharacter
+
+
+@patch("rpg.character.genai")
+def test_generate_responses_strips_code_fence_on_fallback(mock_genai):
+    mock_model = MagicMock()
+    mock_model.generate_content.return_value = MagicMock(
+        text="```json\nNot valid\n```"
+    )
+    mock_genai.GenerativeModel.return_value = mock_model
+
+    spec = {
+        "MarkdownContext": "Faction context",
+        "end_states": ["end"],
+        "initial_states": ["initial"],
+        "gaps": ["gap"],
+    }
+    profile = {
+        "name": "Test NPC",
+        "faction": "Testers",
+        "perks": "",
+        "motivations": "",
+        "background": "",
+        "weaknesses": "",
+    }
+
+    character = YamlCharacter("Test NPC", spec, profile)
+    partner = SimpleNamespace(
+        display_name="Player", faction="Allies", triplets=character.triplets
+    )
+
+    options = character.generate_responses([], [], partner)
+
+    assert [option.text for option in options] == ["Not valid"]
+    assert all(option.type == "chat" for option in options)

--- a/tests/test_npc_action_selection.py
+++ b/tests/test_npc_action_selection.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock, patch
+
+from rpg.game_state import GameState
+from rpg.character import ResponseOption
+
+
+class DummyCharacter:
+    def __init__(self) -> None:
+        self.name = "Victor"
+        self.display_name = "Victor Representative"
+        self.faction = "Corporations"
+        self.progress_key = "Corporations"
+        self.progress_label = "Corporations"
+        self.triplets = [("init", "end", "gap")]
+        self.weights = [1]
+
+    def attribute_score(self, _attribute):
+        return 0
+
+
+@patch("rpg.character.genai")
+def test_log_npc_responses_only_tracks_displayed_action(mock_genai):
+    mock_model = MagicMock()
+    mock_model.generate_content.return_value = MagicMock(text="[]")
+    mock_genai.GenerativeModel.return_value = mock_model
+
+    character = DummyCharacter()
+    state = GameState([character])
+    primary_action = ResponseOption(
+        text="Deploy joint safeguards",
+        type="action",
+        related_triplet=1,
+        related_attribute="technology",
+    )
+    secondary_action = ResponseOption(
+        text="Launch new public relations campaign",
+        type="action",
+        related_triplet=1,
+        related_attribute="network",
+    )
+
+    state.log_npc_responses(character, [primary_action, secondary_action])
+
+    stored_actions = state.available_npc_actions(character)
+    assert [option.text for option in stored_actions] == [primary_action.text]
+    assert all(option.text != secondary_action.text for option in stored_actions)


### PR DESCRIPTION
## Summary
- filter markdown code fences out of the fallback response parsing so NPC chat no longer shows raw ```json snippets
- ensure the game state only exposes the NPC action that was actually surfaced in conversation when multiple actions are generated
- add regression tests covering NPC action filtering and the fallback response cleanup

## Testing
- PYTHONPATH=. pytest tests/test_npc_action_selection.py tests/test_character_fallback.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ecabd15a388333a8c846f432456c10