### PR TITLE
Refine automated players and scenario management

### DIFF
--- a/cli_game.py
+++ b/cli_game.py
@@ -81,6 +81,14 @@ def load_characters(
     context_payload = _load_yaml(context_path) if context_path else {}
     triplet_specs = _faction_mapping(scenario_payload)
     context_specs = _faction_mapping(context_payload)
+    scenario_summary = ""
+    if isinstance(scenario_payload, dict):
+        summary_value = scenario_payload.get("summary") or scenario_payload.get("Summary")
+        if isinstance(summary_value, str):
+            scenario_summary = summary_value.strip()
+        elif isinstance(summary_value, list):
+            parts = [str(item).strip() for item in summary_value if str(item).strip()]
+            scenario_summary = "\n".join(parts)
     if not triplet_specs:
         logger.error("No faction definitions found in scenario file %s", resolved_scenario)
     characters: List[YamlCharacter] = []
@@ -105,7 +113,10 @@ def load_characters(
                 combined_spec["MarkdownContext"] = context_spec["MarkdownContext"]
             for key, value in context_spec.items():
                 combined_spec.setdefault(key, value)
-        characters.append(YamlCharacter(name, combined_spec, entry))
+        character = YamlCharacter(name, combined_spec, entry)
+        if scenario_summary:
+            setattr(character, "scenario_summary", scenario_summary)
+        characters.append(character)
     return characters
 
 

--- a/evaluations/assessment_baseline.py
+++ b/evaluations/assessment_baseline.py
@@ -20,8 +20,13 @@ from rpg.game_state import GameState
 from rpg.assessment_agent import AssessmentAgent
 
 
-def run_baseline_assessment() -> str:
-    """Execute baseline assessment scenarios and return textual results."""
+def run_baseline_assessment(scenario_name: str | None = None) -> str:
+    """Execute baseline assessment scenarios and return textual results.
+
+    Args:
+        scenario_name: Optional scenario identifier to load instead of the
+            configuration default.
+    """
     if load_dotenv is None or genai is None:
         return "optional dependencies not installed"
     load_dotenv()
@@ -30,7 +35,7 @@ def run_baseline_assessment() -> str:
     if not api_key or api_key == placeholder:
         return "GEMINI_API_KEY environment variable not set"
     genai.configure(api_key=api_key)
-    characters = load_characters()
+    characters = load_characters(scenario_name=scenario_name)
     state = GameState(characters)
     assessor = AssessmentAgent()
 

--- a/evaluations/assessment_consistency.py
+++ b/evaluations/assessment_consistency.py
@@ -20,8 +20,13 @@ from rpg.game_state import GameState
 from rpg.assessment_agent import AssessmentAgent
 
 
-def run_consistency_assessment() -> str:
-    """Execute the same assessment multiple times and return results."""
+def run_consistency_assessment(scenario_name: str | None = None) -> str:
+    """Execute the same assessment multiple times and return results.
+
+    Args:
+        scenario_name: Optional scenario identifier to load instead of the
+            configuration default.
+    """
     if load_dotenv is None or genai is None:
         return "optional dependencies not installed"
     load_dotenv()
@@ -30,7 +35,7 @@ def run_consistency_assessment() -> str:
     if not api_key or api_key == placeholder:
         return "GEMINI_API_KEY environment variable not set"
     genai.configure(api_key=api_key)
-    characters = load_characters()
+    characters = load_characters(scenario_name=scenario_name)
     state = GameState(characters)
     assessor = AssessmentAgent()
     history = []

--- a/player_game.py
+++ b/player_game.py
@@ -12,23 +12,23 @@ from typing import Dict
 from cli_game import load_characters
 from rpg.game_state import GameState, WIN_THRESHOLD
 from rpg.assessment_agent import AssessmentAgent
-from players import RandomPlayer, GeminiWinPlayer, GeminiGovCorpPlayer
+from players import (
+    GeminiCivilSocietyPlayer,
+    GeminiCorporationPlayer,
+    RandomPlayer,
+)
 
 
 def create_players(characters) -> Dict[str, object]:
     """Return available player instances based on characters."""
-    gov_ctx = next(
-        (c.base_context for c in characters if c.faction == "Governments"),
-        "",
-    )
     corp_ctx = next(
         (c.base_context for c in characters if c.faction == "Corporations"),
         "",
     )
     return {
         "random": RandomPlayer(),
-        "gemini-win": GeminiWinPlayer(),
-        "gemini-govcorp": GeminiGovCorpPlayer(gov_ctx, corp_ctx),
+        "civil-society": GeminiCivilSocietyPlayer(),
+        "corporation": GeminiCorporationPlayer(corp_ctx),
     }
 
 
@@ -39,14 +39,19 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--player",
-        choices=["random", "gemini-win", "gemini-govcorp"],
+        choices=["random", "civil-society", "corporation"],
         default="random",
         help="Which automated player to use",
+    )
+    parser.add_argument(
+        "--scenario",
+        default=None,
+        help="Scenario name to load (defaults to configuration)",
     )
     parser.add_argument("--rounds", type=int, default=10, help="Number of rounds to play")
     args = parser.parse_args()
 
-    characters = load_characters()
+    characters = load_characters(scenario_name=args.scenario)
     state = GameState(list(characters))
     assessor = AssessmentAgent()
     players = create_players(characters)

--- a/player_manager.py
+++ b/player_manager.py
@@ -92,6 +92,15 @@ class PlayerManager:
                 logger.info("Beginning round %d", round_index)
                 player.take_turn(state, self._assessor)
                 character_label = state.history[-1][0] if state.history else ""
+                attempt = state.last_action_attempt
+                attribute_label = "None"
+                action_text = ""
+                if attempt is not None:
+                    if attempt.attribute:
+                        attribute_label = attempt.attribute.replace("_", " ").title()
+                    else:
+                        attribute_label = "None"
+                    action_text = attempt.option.text
                 final_score = state.final_weighted_score()
                 faction_scores = {}
                 for key, scores in state.progress.items():
@@ -104,6 +113,8 @@ class PlayerManager:
                     {
                         "round": round_index,
                         "character": character_label,
+                        "action": action_text,
+                        "attribute": attribute_label,
                         "score": final_score,
                         "factions": faction_scores,
                     }

--- a/player_service.py
+++ b/player_service.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Set
 import logging
 import os
 import tempfile
+from pathlib import Path
 
 from flask import Flask, abort, redirect, request, send_from_directory
 
@@ -15,8 +16,14 @@ from cli_game import load_characters
 from evaluations.assessment_baseline import run_baseline_assessment
 from evaluations.assessment_consistency import run_consistency_assessment
 from player_manager import PlayerManager
-from players import GeminiGovCorpPlayer, GeminiWinPlayer, RandomPlayer
+from players import (
+    GeminiCivilSocietyPlayer,
+    GeminiCorporationPlayer,
+    Player,
+    RandomPlayer,
+)
 from rpg.assessment_agent import AssessmentAgent
+from rpg.config import load_game_config
 
 
 logger = logging.getLogger(__name__)
@@ -27,16 +34,52 @@ def create_app(log_dir: str | None = None) -> Flask:
 
     logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
     app = Flask(__name__)
-    characters = load_characters()
     assessor = AssessmentAgent()
-    players: Dict[str, Player] = {
-        "random": RandomPlayer(),
-        "gemini-win": GeminiWinPlayer(),
-        "gemini-govcorp": GeminiGovCorpPlayer(
-            next((c.base_context for c in characters if c.faction == "Governments"), ""),
-            next((c.base_context for c in characters if c.faction == "Corporations"), ""),
-        ),
+
+    config = load_game_config()
+    scenario_dir = Path(__file__).resolve().parent / "scenarios"
+    scenario_files = sorted(p for p in scenario_dir.glob("*.yaml"))
+    scenario_lookup: Dict[str, str] = {
+        path.stem.lower(): path.stem for path in scenario_files
     }
+    config_default = config.scenario.lower()
+    scenario_names = [path.stem for path in scenario_files]
+    if not scenario_names:
+        scenario_names = [config_default]
+        scenario_lookup.setdefault(config_default, config_default)
+    elif config_default not in {name.lower() for name in scenario_names}:
+        scenario_lookup.setdefault(config_default, config_default)
+        scenario_names.append(scenario_lookup[config_default])
+
+    def _format_scenario_label(key: str) -> str:
+        label = key.replace("_", " ").replace("-", " ")
+        return label.title() if label else key
+
+    if scenario_lookup:
+        default_scenario_name = scenario_lookup.get(config_default, scenario_names[0])
+    else:
+        default_scenario_name = config_default
+        scenario_lookup[config_default] = config_default
+        scenario_names = [config_default]
+
+    current_scenario_name = default_scenario_name
+
+    player_choices = [
+        ("random", "Random (uniform choice)"),
+        ("civil-society", "Civil society strategist"),
+        ("corporation", "Corporation advocate"),
+    ]
+
+    def _build_players(characters) -> Dict[str, Player]:
+        corporation_context = next(
+            (c.base_context for c in characters if c.faction == "Corporations"),
+            "",
+        )
+        return {
+            "random": RandomPlayer(),
+            "civil-society": GeminiCivilSocietyPlayer(),
+            "corporation": GeminiCorporationPlayer(corporation_context),
+        }
     if log_dir is None:
         try:
             os.makedirs(app.instance_path, exist_ok=True)
@@ -53,16 +96,26 @@ def create_app(log_dir: str | None = None) -> Flask:
             )
     os.makedirs(log_dir, exist_ok=True)
     app.config["PLAYER_LOG_DIR"] = log_dir
-    manager = PlayerManager(characters, assessor, log_dir)
     game_runs: List[Dict[str, object]] = []
     known_logs: Set[str] = set()
     last_run: Dict[str, object] = {}
 
     @app.route("/", methods=["GET", "POST"])
     def index():
-        nonlocal game_runs, known_logs, last_run
+        nonlocal game_runs, known_logs, last_run, current_scenario_name
         if request.method == "POST":
-            player_key = request.form["player"]
+            requested_scenario = request.form.get("scenario", current_scenario_name)
+            scenario_key = scenario_lookup.get(
+                requested_scenario.lower(), current_scenario_name
+            )
+            current_scenario_name = scenario_key
+            characters = load_characters(scenario_name=scenario_key)
+            players = _build_players(characters)
+            manager = PlayerManager(characters, assessor, log_dir)
+            player_key = request.form.get("player", "random")
+            if player_key not in players:
+                logger.warning("Unknown player key '%s'; defaulting to random", player_key)
+                player_key = "random"
             try:
                 rounds = int(request.form.get("rounds", "10"))
             except ValueError:
@@ -74,24 +127,47 @@ def create_app(log_dir: str | None = None) -> Flask:
             rounds = max(1, rounds)
             games = max(1, games)
             logger.info(
-                "Starting sequence for player %s: %d games with %d rounds each",
+                "Starting sequence for player %s on scenario %s: %d games with %d rounds each",
                 player_key,
+                scenario_key,
                 games,
                 rounds,
             )
             player = players[player_key]
             game_runs = manager.run_sequence(player_key, player, games, rounds)
             known_logs = {entry["log_filename"] for entry in game_runs}
-            last_run = {"player": player_key, "rounds": rounds, "games": games}
+            last_run = {
+                "player": player_key,
+                "rounds": rounds,
+                "games": games,
+                "scenario": scenario_key,
+                "scenario_label": _format_scenario_label(scenario_key),
+            }
             return redirect("/progress")
         logger.info("Showing main player selection page")
-        options = "".join(
-            f'<option value="{key}">{key}</option>' for key in players
+        selected_player = last_run.get("player", player_choices[0][0])
+        player_options = "".join(
+            "<option value='{key}'{selected}>{label}</option>".format(
+                key=key,
+                label=label,
+                selected=" selected" if key == selected_player else "",
+            )
+            for key, label in player_choices
+        )
+        selected_scenario = last_run.get("scenario", current_scenario_name)
+        scenario_options = "".join(
+            "<option value='{value}'{selected}>{label}</option>".format(
+                value=name,
+                label=_format_scenario_label(name),
+                selected=" selected" if name == selected_scenario else "",
+            )
+            for name in scenario_names
         )
         return (
             "<h1>Automated Player Manager</h1>"
             "<form method='post'>"
-            f"<label>Player: <select name='player'>{options}</select></label><br>"
+            f"<label>Scenario: <select name='scenario'>{scenario_options}</select></label><br>"
+            f"<label>Player: <select name='player'>{player_options}</select></label><br>"
             "<label>Games: <input type='number' min='1' name='games' value='1'></label><br>"
             "<label>Rounds per game: <input type='number' min='1' name='rounds' value='10'></label><br>"
             "<button type='submit'>Run Sequence</button>"
@@ -111,6 +187,7 @@ def create_app(log_dir: str | None = None) -> Flask:
             f"<div>Selected player: {last_run.get('player', '')}</div>"
             f"<div>Games requested: {last_run.get('games', 0)}</div>"
             f"<div>Rounds per game: {last_run.get('rounds', 0)}</div>"
+            f"<div>Scenario: {last_run.get('scenario_label', last_run.get('scenario', current_scenario_name))}</div>"
         )
 
         def faction_score_lines(faction_data: Dict[str, Dict[str, object]]) -> str:
@@ -126,9 +203,10 @@ def create_app(log_dir: str | None = None) -> Flask:
         sections = []
         for entry in game_runs:
             rows = "".join(
-                "<tr><td>{round}</td><td>{character}</td><td>{score}</td><td>{factions}</td></tr>".format(
+                "<tr><td>{round}</td><td>{character}</td><td>{attribute}</td><td>{score}</td><td>{factions}</td></tr>".format(
                     round=round_info["round"],
                     character=round_info["character"],
+                    attribute=round_info.get("attribute", ""),
                     score=round_info["score"],
                     factions=faction_score_lines(round_info["factions"]),
                 )
@@ -145,7 +223,7 @@ def create_app(log_dir: str | None = None) -> Flask:
                     f"<div>Final faction scores:<br>{final_factions}</div>"
                     f"<div><a href='/logs/{entry['log_filename']}'>Download log</a></div>"
                     "<h3>Round-by-round progress</h3>"
-                    "<table><tr><th>Round</th><th>Character</th><th>Weighted Score</th><th>Faction Scores</th></tr>"
+                    "<table><tr><th>Round</th><th>Character</th><th>Attribute</th><th>Weighted Score</th><th>Faction Scores</th></tr>"
                     + rows
                     + "</table></section>"
                 )
@@ -166,7 +244,8 @@ def create_app(log_dir: str | None = None) -> Flask:
 
     @app.route("/evaluation/baseline", methods=["POST"])
     def baseline_evaluation():
-        result = run_baseline_assessment()
+        scenario = last_run.get("scenario") if last_run else None
+        result = run_baseline_assessment(scenario_name=scenario)
         return (
             "<h1>Baseline Assessment</h1>"
             f"<pre>{result}</pre>"
@@ -175,7 +254,8 @@ def create_app(log_dir: str | None = None) -> Flask:
 
     @app.route("/evaluation/consistency", methods=["POST"])
     def consistency_evaluation():
-        result = run_consistency_assessment()
+        scenario = last_run.get("scenario") if last_run else None
+        result = run_consistency_assessment(scenario_name=scenario)
         return (
             "<h1>Consistency Assessment</h1>"
             f"<pre>{result}</pre>"

--- a/tests/fixtures/scenarios/complete.yaml
+++ b/tests/fixtures/scenarios/complete.yaml
@@ -1,6 +1,7 @@
 summary: "Test scenario summary."
 
 test_character:
+  scenario_summary: "Test scenario summary."
   end_states:
     - end1
     - end2

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -10,7 +10,11 @@ import yaml
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from players import GeminiGovCorpPlayer, GeminiWinPlayer, RandomPlayer
+from players import (
+    GeminiCivilSocietyPlayer,
+    GeminiCorporationPlayer,
+    RandomPlayer,
+)
 from rpg.assessment_agent import AssessmentAgent
 from rpg.game_state import GameState
 from rpg.character import ResponseOption, YamlCharacter
@@ -88,6 +92,8 @@ class PlayerTests(unittest.TestCase):
             (char.display_name, "A"),
         )
         self.assertEqual(state.progress[char.progress_key], [10, 20, 30])
+        self.assertIsNotNone(state.last_action_attempt)
+        self.assertEqual(state.last_action_attempt.attribute, "leadership")
 
     @patch("players.genai")
     @patch("rpg.character.genai")
@@ -98,7 +104,7 @@ class PlayerTests(unittest.TestCase):
         mock_char_genai.GenerativeModel.return_value = MagicMock()
         char = _load_test_character()
         state = GameState([char])
-        player = GeminiWinPlayer()
+        player = GeminiCivilSocietyPlayer()
         actions = [
             ResponseOption(text="A", type="action"),
             ResponseOption(text="B", type="action"),
@@ -111,14 +117,14 @@ class PlayerTests(unittest.TestCase):
 
     @patch("players.genai")
     @patch("rpg.character.genai")
-    def test_govcorp_context(self, mock_char_genai, mock_players_genai):
+    def test_corporation_context(self, mock_char_genai, mock_players_genai):
         mock_model = MagicMock()
         mock_model.generate_content.return_value = MagicMock(text="1")
         mock_players_genai.GenerativeModel.return_value = mock_model
         mock_char_genai.GenerativeModel.return_value = MagicMock()
         char = _load_test_character()
         gov_ctx = corp_ctx = "CTX"
-        player = GeminiGovCorpPlayer(gov_ctx, corp_ctx)
+        player = GeminiCorporationPlayer(corp_ctx)
         state = GameState([char])
         actions = [
             ResponseOption(text="A", type="action"),


### PR DESCRIPTION
## Summary
- add dedicated civil-society and corporation Gemini player implementations while keeping the random agent and legacy aliases intact
- enhance the player service with scenario selection, attribute-aware progress reporting, and scenario-aware evaluation calls
- capture scenario summaries from character data, surface action attributes in logs, and update fixtures/tests accordingly

## Testing
- GEMINI_API_KEY="" pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68f012ed3c288333a6cd41eb5c2d7ff3