### PR TITLE
Add credibility gating, configurable rolls, and refreshed web UI

### DIFF
--- a/cli_game.py
+++ b/cli_game.py
@@ -133,7 +133,13 @@ def main() -> None:
         convo = state.conversation_history(char)
         for entry in convo:
             print(f"{entry.speaker}: {entry.text} ({entry.type})")
-        responses = player.generate_responses(state.history, convo, char)
+        partner_credibility = state.current_credibility(getattr(char, "faction", None))
+        responses = player.generate_responses(
+            state.history,
+            convo,
+            char,
+            partner_credibility=partner_credibility,
+        )
         npc_actions = list(state.available_npc_actions(char))
         combined_options = list(responses)
         existing_texts = {opt.text for opt in combined_options}
@@ -170,7 +176,12 @@ def main() -> None:
                 state.finalize_failed_action(char, option)
                 break
             break
-        npc_responses = char.generate_responses(state.history, state.conversation_history(char), player)
+        npc_responses = char.generate_responses(
+            state.history,
+            state.conversation_history(char),
+            player,
+            partner_credibility=partner_credibility,
+        )
         state.log_npc_responses(char, npc_responses)
         npc_actions = list(state.available_npc_actions(char))
         if npc_actions:

--- a/game_config.yaml
+++ b/game_config.yaml
@@ -2,3 +2,4 @@ game:
   scenario: complete
   win_threshold: 71
   max_rounds: 10
+  roll_success_threshold: 10

--- a/player_game.py
+++ b/player_game.py
@@ -10,7 +10,7 @@ import os
 from typing import Dict
 
 from cli_game import load_characters
-from rpg.game_state import GameState, WIN_THRESHOLD
+from rpg.game_state import GameState
 from rpg.assessment_agent import AssessmentAgent
 from players import (
     GeminiCivilSocietyPlayer,
@@ -61,7 +61,7 @@ def main() -> None:
     for round_num in range(1, args.rounds + 1):
         logger.info("Round %d", round_num)
         player.take_turn(state, assessor)
-        if state.final_weighted_score() >= WIN_THRESHOLD:
+        if state.final_weighted_score() >= state.config.win_threshold:
             logger.info("Final score threshold reached; ending game")
             break
 

--- a/player_manager.py
+++ b/player_manager.py
@@ -10,7 +10,7 @@ from typing import Dict, Iterable, List
 from uuid import uuid4
 
 from rpg.assessment_agent import AssessmentAgent
-from rpg.game_state import GameState, WIN_THRESHOLD
+from rpg.game_state import GameState
 from players import Player
 
 
@@ -125,7 +125,7 @@ class PlayerManager:
                     character_label,
                     final_score,
                 )
-                if final_score >= WIN_THRESHOLD:
+                if final_score >= state.config.win_threshold:
                     logger.info(
                         "Final score threshold reached for game %d; ending early", game_index
                     )
@@ -140,7 +140,7 @@ class PlayerManager:
             "game_number": game_index,
             "rounds": rounds_progress,
             "final_score": final_score,
-            "result": "Win" if final_score >= WIN_THRESHOLD else "Lose",
+            "result": "Win" if final_score >= state.config.win_threshold else "Lose",
             "iterations": len(rounds_progress),
             "actions": len(state.history),
             "log_filename": log_filename,

--- a/players.py
+++ b/players.py
@@ -45,7 +45,13 @@ class Player(ABC):
         logger.info("Selected character: %s", char.name)
         conversation = state.conversation_history(char)
         partner = state.player_character
-        responses = char.generate_responses(state.history, conversation, partner)
+        credibility = state.current_credibility(getattr(char, "faction", None))
+        responses = char.generate_responses(
+            state.history,
+            conversation,
+            partner,
+            partner_credibility=credibility,
+        )
         actions = [option for option in responses if option.is_action]
         known_texts = {option.text for option in actions}
         for stored_option in state.available_npc_actions(char):

--- a/rpg/config.py
+++ b/rpg/config.py
@@ -21,6 +21,7 @@ class GameConfig:
     scenario: str = "complete"
     win_threshold: int = 71
     max_rounds: int = 10
+    roll_success_threshold: int = 10
 
 
 _DEFAULT_CONFIG_PATH = os.path.join(
@@ -71,10 +72,12 @@ def load_game_config(path: str | None = None) -> GameConfig:
     scenario = str(data.get("scenario", "complete")).strip() or "complete"
     win_threshold = _coerce_int(data.get("win_threshold", 71), 71)
     max_rounds = _coerce_int(data.get("max_rounds", 10), 10)
+    roll_success_threshold = _coerce_int(data.get("roll_success_threshold", 10), 10)
     return GameConfig(
         scenario=scenario.lower(),
         win_threshold=max(0, win_threshold),
         max_rounds=max(1, max_rounds),
+        roll_success_threshold=max(1, roll_success_threshold),
     )
 
 

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -79,7 +79,7 @@ class YamlCharacterTest(unittest.TestCase):
         partner = SimpleNamespace(
             display_name="Player", faction="CivilSociety", triplets=char.triplets
         )
-        actions = char.generate_responses([], [], partner)
+        actions = char.generate_responses([], [], partner, partner_credibility=50)
         prompt_used = mock_action_model.generate_content.call_args_list[0][0][0]
         self.assertIn("end1", prompt_used)
         self.assertIn("size: Small", prompt_used)
@@ -142,7 +142,7 @@ class YamlCharacterTest(unittest.TestCase):
             display_name="Player", faction="CivilSociety", triplets=char.triplets
         )
         with self.assertLogs("rpg.character", level="WARNING") as log_ctx:
-            actions = char.generate_responses([], [], partner)
+            actions = char.generate_responses([], [], partner, partner_credibility=50)
 
         self.assertEqual([action.text for action in actions], ["Act1", "Act2", "Act3"])
         self.assertTrue(
@@ -175,7 +175,7 @@ class YamlCharacterTest(unittest.TestCase):
         partner = SimpleNamespace(
             display_name="NPC", faction="Allies", triplets=[(1, 2, 3)]
         )
-        options = player.generate_responses([], [], partner)
+        options = player.generate_responses([], [], partner, partner_credibility=50)
         expected_texts = [
             "It's good to connect, NPC. What's top of mind for you today?",
             "I'd love to hear your priorities right now, NPC.",

--- a/tests/test_character_fallback.py
+++ b/tests/test_character_fallback.py
@@ -32,7 +32,7 @@ def test_generate_responses_strips_code_fence_on_fallback(mock_genai):
         display_name="Player", faction="Allies", triplets=character.triplets
     )
 
-    options = character.generate_responses([], [], partner)
+    options = character.generate_responses([], [], partner, partner_credibility=50)
 
     assert [option.text for option in options] == ["Not valid"]
     assert all(option.type == "chat" for option in options)

--- a/tests/test_credibility.py
+++ b/tests/test_credibility.py
@@ -29,7 +29,7 @@ class DummyCharacter:
 
 class CredibilityMatrixTests(unittest.TestCase):
     @patch("rpg.character.genai")
-    @patch("rpg.game_state.random.uniform", return_value=0)
+    @patch("rpg.game_state.random.randint", return_value=20)
     def test_record_action_rewards_targets(self, mock_uniform, mock_genai):
         mock_genai.GenerativeModel.return_value = MagicMock()
         character = DummyCharacter("Alice", "Governments")
@@ -44,7 +44,7 @@ class CredibilityMatrixTests(unittest.TestCase):
         self.assertEqual(updated_player, min(100, initial_player + 10))
 
     @patch("rpg.character.genai")
-    @patch("rpg.game_state.random.uniform", return_value=0)
+    @patch("rpg.game_state.random.randint", return_value=20)
     def test_record_action_penalises_targets_with_triplet(
         self, mock_uniform, mock_genai
     ):
@@ -61,7 +61,7 @@ class CredibilityMatrixTests(unittest.TestCase):
         self.assertEqual(updated_player, max(0, initial_player - 30))
 
     @patch("rpg.character.genai")
-    @patch("rpg.game_state.random.uniform", return_value=0)
+    @patch("rpg.game_state.random.randint", return_value=20)
     def test_record_action_without_targets_applies_penalty(
         self, mock_uniform, mock_genai
     ):
@@ -76,7 +76,7 @@ class CredibilityMatrixTests(unittest.TestCase):
         self.assertEqual(updated_player, max(0, initial_player - 30))
 
     @patch("rpg.character.genai")
-    @patch("rpg.game_state.random.uniform", return_value=0)
+    @patch("rpg.game_state.random.randint", return_value=20)
     def test_unknown_faction_initialises_defaults(self, mock_uniform, mock_genai):
         mock_genai.GenerativeModel.return_value = MagicMock()
         outsider = DummyCharacter("Bob", "NewFaction")

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -39,7 +39,14 @@ def test_async_response_generation(mock_char_genai, mock_assess_genai):
     start_evt = threading.Event()
     finish_evt = threading.Event()
 
-    def slow_responses(self, history, conversation, partner):
+    def slow_responses(
+        self,
+        history,
+        conversation,
+        partner,
+        *,
+        partner_credibility=None,
+    ):
         start_evt.set()
         finish_evt.wait()
         return [ResponseOption(text="A", type="action")]
@@ -75,7 +82,14 @@ def test_async_npc_responses(mock_char_genai, mock_assess_genai):
     finish_evt = threading.Event()
     completed_evt = threading.Event()
 
-    def player_options(self, history, conversation, partner):
+    def player_options(
+        self,
+        history,
+        conversation,
+        partner,
+        *,
+        partner_credibility=None,
+    ):
         return [
             ResponseOption(text="Starter 1", type="chat"),
             ResponseOption(text="Starter 2", type="chat"),
@@ -84,7 +98,14 @@ def test_async_npc_responses(mock_char_genai, mock_assess_genai):
 
     observed_conversations: list[str] = []
 
-    def slow_npc(self, history, conversation, partner):
+    def slow_npc(
+        self,
+        history,
+        conversation,
+        partner,
+        *,
+        partner_credibility=None,
+    ):
         start_evt.set()
         finish_evt.wait()
         completed_evt.set()
@@ -162,7 +183,14 @@ def test_assessment_background_wait(mock_char_genai, mock_assess_genai):
         related_attribute="leadership",
     )
 
-    def static_responses(self, history, conversation, partner):
+    def static_responses(
+        self,
+        history,
+        conversation,
+        partner,
+        *,
+        partner_credibility=None,
+    ):
         return [action_option]
 
     start_evt = threading.Event()
@@ -184,7 +212,7 @@ def test_assessment_background_wait(mock_char_genai, mock_assess_genai):
                 client = app.test_client()
                 client.get("/start")
                 payload = json.dumps(action_option.to_payload())
-                with patch("rpg.game_state.random.uniform", return_value=0):
+                with patch("rpg.game_state.random.randint", return_value=20):
                     resp = client.post(
                         "/actions",
                         data={"character": "0", "response": payload},

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -82,7 +82,7 @@ class PlayerServiceTest(unittest.TestCase):
 
                 mock_choice.side_effect = choice_side_effect
                 with patch("player_service.load_characters", return_value=[character]):
-                    with patch("rpg.game_state.random.uniform", return_value=0):
+                    with patch("rpg.game_state.random.randint", return_value=20):
                         app = create_app(log_dir=tmpdir)
                         client = app.test_client()
 

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -41,7 +41,7 @@ class PlayerTests(unittest.TestCase):
     @patch("players.random.choice")
     @patch("rpg.assessment_agent.genai")
     @patch("rpg.character.genai")
-    @patch("rpg.game_state.random.uniform", return_value=0)
+    @patch("rpg.game_state.random.randint", return_value=20)
     def test_random_player_turn(
         self, mock_uniform, mock_char_genai, mock_assess_genai, mock_choice
     ):

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -32,7 +32,7 @@ def _load_test_character() -> YamlCharacter:
 
 
 class WebServiceTest(unittest.TestCase):
-    @patch("rpg.game_state.random.uniform", return_value=0)
+    @patch("rpg.game_state.random.randint", return_value=20)
     def test_conversation_and_win_flow(self, mock_uniform):
         with patch("rpg.character.genai") as mock_char_genai, patch(
             "rpg.assessment_agent.genai"


### PR DESCRIPTION
## Summary
- gate NPC action prompts when player credibility cannot cover triplet commitments and log warnings if models violate the restriction
- switch action resolution to a d20 plus attribute roll against a configurable threshold, tracking in-game time after each attempt and reroll
- expose all configuration values (scenario, win threshold, max rounds, roll threshold) through the web landing page alongside updated instructions and time tracking, and update tests to exercise the new APIs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68f01aee20ec8333b80610c4934b364d