### PR TITLE
Fix player service module imports for direct execution

### DIFF
--- a/evaluations/player_service.py
+++ b/evaluations/player_service.py
@@ -7,17 +7,23 @@ from __future__ import annotations
 from typing import Dict, List, Set
 import logging
 import os
+import sys
 import tempfile
 from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 from flask import Flask, abort, redirect, request, send_from_directory
 
 from cli_game import load_characters
 
-from .assessment_baseline import run_baseline_assessment
-from .assessment_consistency import run_consistency_assessment
-from .player_manager import PlayerManager
-from .players import (
+from evaluations.assessment_baseline import run_baseline_assessment
+from evaluations.assessment_consistency import run_consistency_assessment
+from evaluations.player_manager import PlayerManager
+from evaluations.players import (
     GeminiCivilSocietyPlayer,
     GeminiCorporationPlayer,
     Player,


### PR DESCRIPTION
## Summary
- add the repository root to `sys.path` so `cli_game` can be imported when the player service runs as a script
- convert relative imports in `player_service` to absolute package imports to avoid ImportError outside a package context

## Testing
- python evaluations/player_service.py --help

------
https://chatgpt.com/codex/tasks/task_e_68f4148e0c3c8333b546615f28185d3b