### PR TITLE
Handle wrapped response payloads when parsing options

### DIFF
--- a/rpg/character.py
+++ b/rpg/character.py
@@ -262,8 +262,16 @@ class Character(ABC):
 
         responses: List[ResponseOption] = []
         payload = parsed_payload
-        if isinstance(payload, dict) and "actions" in payload:
-            payload = payload["actions"]
+        if isinstance(payload, dict):
+            list_candidates = (
+                payload.get("actions"),
+                payload.get("responses"),
+                payload.get("options"),
+            )
+            for candidate in list_candidates:
+                if isinstance(candidate, list):
+                    payload = candidate
+                    break
         if isinstance(payload, list):
             for entry in payload:
                 if not isinstance(entry, dict):


### PR DESCRIPTION
## Summary
- parse wrapped model responses that provide `responses` or `options` arrays so chat text is preserved in conversation logs
- add a regression test ensuring characters return the expected chat option text when the payload is wrapped

## Testing
- pytest tests/test_character.py


------
https://chatgpt.com/codex/tasks/task_e_68f418b4a390833391addf0da06000ac