### PR TITLE
Ensure player service can import load_characters

### DIFF
--- a/evaluations/player_service.py
+++ b/evaluations/player_service.py
@@ -7,10 +7,17 @@ from __future__ import annotations
 from typing import Dict, List, Set
 import logging
 import os
+import sys
 import tempfile
 from pathlib import Path
 
 from flask import Flask, abort, redirect, request, send_from_directory
+
+# Ensure the project root is importable when executed as a script.
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from cli_game import load_characters
 


### PR DESCRIPTION
## Summary
- ensure the player service adjusts sys.path so the cli_game module can be imported when executed directly

## Testing
- not run (Flask dependency missing in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f52fb876e0833390cb3beaab5e26b9