### PR TITLE
Persist game execution results to SQLite

### DIFF
--- a/evaluations/game_database.py
+++ b/evaluations/game_database.py
@@ -1,0 +1,270 @@
+"""Database-backed recorder for automated game executions."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from datetime import datetime
+from typing import Dict, Iterable, MutableMapping
+
+from rpg.game_state import ActionAttempt, GameState
+
+from .sqlite3_connector import SQLiteConnector, sanitize_identifier
+
+
+class GameRunObserver:
+    """Minimal interface implemented by observers of game runs."""
+
+    def on_game_start(
+        self,
+        state: GameState,
+        *,
+        player_key: str,
+        player_class: str,
+        automated_player_class: str,
+        game_index: int,
+    ) -> None:
+        raise NotImplementedError
+
+    def before_turn(self, state: GameState, round_index: int) -> None:
+        raise NotImplementedError
+
+    def after_turn(self, state: GameState, round_index: int) -> None:
+        raise NotImplementedError
+
+    def on_game_end(
+        self,
+        state: GameState,
+        *,
+        result: str,
+        successful: bool,
+        error: str | None = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def on_game_error(
+        self, state: GameState | None, error: BaseException | str
+    ) -> None:
+        raise NotImplementedError
+
+
+class GameDatabaseRecorder(GameRunObserver):
+    """Persist execution metadata, actions, and assessments to SQLite."""
+
+    def __init__(
+        self,
+        connector: SQLiteConnector,
+        *,
+        notes: str | None = None,
+    ) -> None:
+        self._connector = connector
+        self._notes = notes
+        self._execution_id: int | None = None
+        self._pre_turn_snapshot: Dict[str, list[int]] | None = None
+        self._cached_credibility_targets: Iterable[str] | None = None
+        self._faction_triplet_counts: Dict[str, int] | None = None
+        self._result_recorded = False
+
+    # Interface implementation -----------------------------------------
+    def on_game_start(
+        self,
+        state: GameState,
+        *,
+        player_key: str,
+        player_class: str,
+        automated_player_class: str,
+        game_index: int,
+    ) -> None:
+        self._faction_triplet_counts = {
+            faction: len(scores)
+            for faction, scores in state.progress.items()
+        }
+        credibility_snapshot = state.credibility.snapshot()
+        player_row = credibility_snapshot.get(state.player_faction, {})
+        self._cached_credibility_targets = list(player_row.keys())
+        self._connector.initialise()
+        self._connector.ensure_dynamic_schema(
+            self._faction_triplet_counts,
+            self._cached_credibility_targets,
+        )
+        config_payload = asdict(state.config)
+        log_level = os.environ.get("LOG_LEVEL")
+        enable_parallelism = os.environ.get("ENABLE_PARALLELISM")
+        automated_agent_max_exchanges = os.environ.get(
+            "AUTOMATED_AGENT_MAX_EXCHANGES"
+        )
+        try:
+            max_exchanges_int = (
+                int(automated_agent_max_exchanges)
+                if automated_agent_max_exchanges is not None
+                else None
+            )
+        except ValueError:
+            max_exchanges_int = None
+        metadata = {
+            "player_class": player_class,
+            "automated_player_class": automated_player_class,
+            "config_json": json.dumps(config_payload, sort_keys=True),
+            "log_level": log_level,
+            "enable_parallelism": enable_parallelism,
+            "automated_agent_max_exchanges": max_exchanges_int,
+            "scenario": state.config.scenario,
+            "win_threshold": state.config.win_threshold,
+            "max_rounds": state.config.max_rounds,
+            "roll_success_threshold": state.config.roll_success_threshold,
+            "notes": self._notes or f"{player_key}-game-{game_index}-{datetime.utcnow().isoformat()}",
+        }
+        metadata = {key: value for key, value in metadata.items() if value is not None}
+        self._execution_id = self._connector.insert_execution(metadata)
+        self._connector.commit()
+        self._result_recorded = False
+
+    def before_turn(self, state: GameState, round_index: int) -> None:
+        self._pre_turn_snapshot = self._snapshot_progress(state)
+
+    def after_turn(self, state: GameState, round_index: int) -> None:
+        if self._execution_id is None:
+            return
+        attempt = state.last_action_attempt
+        if attempt is None:
+            return
+        action_id = self._record_action(state, attempt, round_index)
+        self._record_assessment(state, action_id)
+        self._record_credibility(state, attempt, action_id)
+        self._connector.commit()
+        self._pre_turn_snapshot = self._snapshot_progress(state)
+
+    def on_game_end(
+        self,
+        state: GameState,
+        *,
+        result: str,
+        successful: bool,
+        error: str | None = None,
+    ) -> None:
+        if self._execution_id is not None:
+            self._record_result(
+                successful_execution=successful,
+                result=result,
+                error_info=error,
+            )
+            self._connector.commit()
+        self._reset()
+
+    def on_game_error(
+        self, state: GameState | None, error: BaseException | str
+    ) -> None:
+        if self._execution_id is None:
+            self._reset()
+            return
+        self._record_result(
+            successful_execution=False,
+            result="N/A",
+            error_info=str(error),
+        )
+        self._connector.commit()
+        self._reset()
+
+    # Internal helpers ---------------------------------------------------
+    def _snapshot_progress(self, state: GameState) -> Dict[str, list[int]]:
+        return {key: list(values) for key, values in state.progress.items()}
+
+    def _record_action(self, state: GameState, attempt: ActionAttempt, round_index: int) -> int:
+        option_payload = attempt.option.to_payload()
+        data: MutableMapping[str, object] = {
+            "execution_id": self._execution_id,
+            "actor": state.last_action_actor,
+            "title": attempt.label,
+            "option_text": attempt.option.text,
+            "option_type": attempt.option.type,
+            "related_triplet": attempt.option.related_triplet,
+            "related_attribute": attempt.option.related_attribute,
+            "success": int(attempt.success),
+            "roll_total": attempt.roll + attempt.effective_score,
+            "actor_score": attempt.actor_score,
+            "player_score": attempt.player_score,
+            "effective_score": attempt.effective_score,
+            "credibility_cost": attempt.credibility_cost,
+            "credibility_gain": attempt.credibility_gain,
+            "targets_json": list(attempt.targets),
+            "failure_text": attempt.failure_text,
+            "round_number": round_index,
+            "option_json": option_payload,
+        }
+        return self._connector.insert_action(data)
+
+    def _record_assessment(self, state: GameState, action_id: int) -> None:
+        if self._faction_triplet_counts is None:
+            self._faction_triplet_counts = {
+                faction: len(scores)
+                for faction, scores in state.progress.items()
+            }
+        assessment_data: Dict[str, object] = {
+            "execution_id": self._execution_id,
+            "action_id": action_id,
+            "scenario": state.config.scenario,
+            "final_weighted_score": state.final_weighted_score(),
+        }
+        detailed_scores: Dict[str, Dict[str, int]] = {}
+        for faction, scores in state.progress.items():
+            faction_key = sanitize_identifier(faction)
+            faction_detail: Dict[str, int] = {}
+            for index, score in enumerate(scores, 1):
+                column = f"{faction_key}_triplet_{index}"
+                assessment_data[column] = score
+                faction_detail[str(index)] = score
+            detailed_scores[faction] = faction_detail
+        assessment_data["assessment_json"] = {
+            "before": self._pre_turn_snapshot,
+            "after": detailed_scores,
+        }
+        self._connector.insert_assessment(assessment_data)
+
+    def _record_credibility(self, state: GameState, attempt: ActionAttempt, action_id: int) -> None:
+        snapshot = state.credibility.snapshot()
+        player_row = snapshot.get(state.player_faction, {})
+        if self._cached_credibility_targets is None:
+            self._cached_credibility_targets = list(player_row.keys())
+        credibility_data: Dict[str, object] = {
+            "execution_id": self._execution_id,
+            "action_id": action_id,
+            "cost": attempt.credibility_cost,
+            "reroll_attempt_count": state.last_reroll_count,
+            "credibility_json": player_row,
+        }
+        for target in self._cached_credibility_targets:
+            column = f"credibility_{sanitize_identifier(target)}"
+            credibility_data[column] = player_row.get(target)
+        self._connector.insert_credibility(credibility_data)
+
+    def _record_result(
+        self,
+        *,
+        successful_execution: bool,
+        result: str | None,
+        error_info: str | None,
+    ) -> None:
+        if self._execution_id is None or self._result_recorded:
+            return
+        payload: Dict[str, object] = {
+            "execution_id": self._execution_id,
+            "successful_execution": successful_execution,
+            "result": result or "N/A",
+        }
+        if error_info:
+            payload["error_info"] = error_info
+        self._connector.insert_result(payload)
+        self._result_recorded = True
+
+    def _reset(self) -> None:
+        self._execution_id = None
+        self._pre_turn_snapshot = None
+        self._cached_credibility_targets = None
+        self._faction_triplet_counts = None
+        self._result_recorded = False
+
+
+__all__ = ["GameRunObserver", "GameDatabaseRecorder"]

--- a/evaluations/players.py
+++ b/evaluations/players.py
@@ -96,6 +96,7 @@ class Player(ABC):
         logger.info("Taking turn")
         partner = state.player_character
         action_performed = False
+        state.last_action_actor = None
         max_exchanges = _conversation_exchange_limit()
         character_attempts = 0
         max_character_attempts = max(1, len(state.characters))
@@ -188,6 +189,7 @@ class Player(ABC):
         if not action_performed:
             logger.info("No action performed during this turn")
             state.last_action_attempt = None
+            state.last_action_actor = None
             return
         scores = assessor.assess(state.characters, state.how_to_win, state.history)
         logger.info("Assessment results: %s", scores)

--- a/evaluations/sqlite3_connector.py
+++ b/evaluations/sqlite3_connector.py
@@ -1,9 +1,187 @@
+"""Utility helpers for interacting with the SQLite evaluation database."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+import os
+import re
 import sqlite3
+from contextlib import contextmanager
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
+from typing import Dict, Iterable, Iterator, Mapping, MutableMapping
 
-db_path = Path("/var/lib/sqlite/main.db")
-conn = sqlite3.connect(db_path)
+_DDL_PATH = Path(__file__).with_name("sqlite3_db.ddl")
+_DEFAULT_DB_PATH = Path(os.environ.get("EVALUATION_SQLITE_PATH", "/var/lib/sqlite/main.db"))
 
-# TODO: implement the necessary sqlite connector logic
 
-conn.close()
+def _ensure_directory(path: Path) -> None:
+    if not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def sanitize_identifier(name: str) -> str:
+    """Return a SQLite-safe identifier derived from ``name``."""
+
+    value = re.sub(r"[^0-9a-zA-Z]+", "_", name.strip().lower())
+    value = value.strip("_") or "value"
+    if value[0].isdigit():
+        value = f"c_{value}"
+    return value
+
+
+class SQLiteConnector:
+    """High level helper that owns the SQLite connection for evaluations."""
+
+    def __init__(self, db_path: Path | str | None = None, ddl_path: Path | str | None = None) -> None:
+        self.db_path = Path(db_path or _DEFAULT_DB_PATH)
+        self.ddl_path = Path(ddl_path or _DDL_PATH)
+        _ensure_directory(self.db_path)
+        self._connection: sqlite3.Connection | None = None
+        self._initialised = False
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        if self._connection is None:
+            self._connection = sqlite3.connect(self.db_path)
+            self._connection.row_factory = sqlite3.Row
+        return self._connection
+
+    def close(self) -> None:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+            self._initialised = False
+
+    @contextmanager
+    def cursor(self) -> Iterator[sqlite3.Cursor]:
+        cur = self.connection.cursor()
+        try:
+            yield cur
+        finally:
+            cur.close()
+
+    def initialise(self) -> None:
+        """Execute the DDL script once per connector lifetime."""
+
+        if self._initialised:
+            return
+        script = self.ddl_path.read_text(encoding="utf-8")
+        self.connection.executescript(script)
+        self._initialised = True
+
+    def commit(self) -> None:
+        self.connection.commit()
+
+    # Column helpers -----------------------------------------------------
+    def _table_columns(self, table: str) -> Dict[str, str]:
+        with self.cursor() as cur:
+            cur.execute(f"PRAGMA table_info({table})")
+            return {row[1]: row[2] for row in cur.fetchall()}
+
+    def ensure_columns(self, table: str, columns: Mapping[str, str]) -> None:
+        existing = self._table_columns(table)
+        for column, declaration in columns.items():
+            if column not in existing:
+                with self.cursor() as cur:
+                    cur.execute(
+                        f"ALTER TABLE {table} ADD COLUMN {column} {declaration}"
+                    )
+
+    # Serialisation helpers ----------------------------------------------
+    @staticmethod
+    def _serialise_json(payload: object) -> str:
+        if is_dataclass(payload):
+            payload = asdict(payload)
+        return json.dumps(payload, sort_keys=True)
+
+    @staticmethod
+    def _prepare_payload(data: MutableMapping[str, object]) -> MutableMapping[str, object]:
+        cleaned: Dict[str, object] = {}
+        for key, value in data.items():
+            if is_dataclass(value):
+                cleaned[key] = asdict(value)
+            else:
+                cleaned[key] = value
+        return cleaned
+
+    def _execute_insert(self, table: str, values: Mapping[str, object]) -> int:
+        if not values:
+            raise ValueError("insert payload cannot be empty")
+        columns = list(values.keys())
+        placeholders = ", ".join(["?"] * len(columns))
+        sql = f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({placeholders})"
+        with self.cursor() as cur:
+            cur.execute(sql, [values[column] for column in columns])
+            return int(cur.lastrowid)
+
+    # Public API ---------------------------------------------------------
+    def insert_execution(self, values: Mapping[str, object]) -> int:
+        payload = dict(self._prepare_payload(dict(values)))
+        if "config_json" in payload and not isinstance(payload["config_json"], str):
+            payload["config_json"] = self._serialise_json(payload["config_json"])
+        return self._execute_insert("executions", payload)
+
+    def insert_action(self, values: Mapping[str, object]) -> int:
+        payload = dict(values)
+        if "option_json" in payload and not isinstance(payload["option_json"], str):
+            payload["option_json"] = self._serialise_json(payload["option_json"])
+        if "targets_json" in payload and not isinstance(payload["targets_json"], str):
+            payload["targets_json"] = self._serialise_json(payload["targets_json"])
+        return self._execute_insert("actions", payload)
+
+    def insert_assessment(self, values: Mapping[str, object]) -> int:
+        payload = dict(values)
+        if "assessment_json" in payload and not isinstance(payload["assessment_json"], str):
+            payload["assessment_json"] = self._serialise_json(payload["assessment_json"])
+        return self._execute_insert("assessments", payload)
+
+    def insert_credibility(self, values: Mapping[str, object]) -> int:
+        payload = dict(values)
+        if "credibility_json" in payload and not isinstance(payload["credibility_json"], str):
+            payload["credibility_json"] = self._serialise_json(payload["credibility_json"])
+        return self._execute_insert("credibility", payload)
+
+    def insert_result(self, values: Mapping[str, object]) -> int:
+        payload = dict(values)
+        if "successful_execution" in payload:
+            payload["successful_execution"] = int(bool(payload["successful_execution"]))
+        return self._execute_insert("results", payload)
+
+    # Dynamic schema helpers --------------------------------------------
+    def ensure_assessment_columns(self, faction_triplets: Mapping[str, int]) -> None:
+        columns = {
+            f"{sanitize_identifier(faction)}_triplet_{index}": "INTEGER"
+            for faction, count in faction_triplets.items()
+            for index in range(1, count + 1)
+        }
+        if columns:
+            self.ensure_columns("assessments", columns)
+
+    def ensure_credibility_columns(self, targets: Iterable[str]) -> None:
+        columns = {
+            f"credibility_{sanitize_identifier(target)}": "INTEGER"
+            for target in targets
+        }
+        if columns:
+            self.ensure_columns("credibility", columns)
+
+    def ensure_dynamic_schema(self, faction_triplets: Mapping[str, int], credibility_targets: Iterable[str]) -> None:
+        self.ensure_assessment_columns(faction_triplets)
+        self.ensure_credibility_columns(credibility_targets)
+
+
+@contextmanager
+def sqlite_connector(db_path: Path | str | None = None) -> Iterator[SQLiteConnector]:
+    connector = SQLiteConnector(db_path=db_path)
+    try:
+        connector.initialise()
+        yield connector
+        connector.commit()
+    finally:
+        connector.close()
+
+
+__all__ = ["SQLiteConnector", "sqlite_connector", "sanitize_identifier"]

--- a/evaluations/sqlite3_db.ddl
+++ b/evaluations/sqlite3_db.ddl
@@ -2,51 +2,79 @@ PRAGMA foreign_keys = ON;
 
 -- 1) Game execution info (one row per run)
 CREATE TABLE IF NOT EXISTS executions (
-  execution_id        INTEGER PRIMARY KEY,
-  player_class        TEXT,          -- starting class/archetype
-  automated_player_class        TEXT,          -- Class name of the players.py, e.g. GeminiCorporationPlayer
-  config_json     TEXT,          -- full config snapshot
-  LOG_LEVEL     TEXT,
-  ENABLE_PARALLELISM  TEXT,
-  AUTOMATED_AGENT_MAX_EXCHANGES INTEGER,
-  scenario    TEXT,
-  win_threshold     INTEGER,
-  max_rounds      INTEGER,
-  roll_success_threshold      INTEGER,
-  notes               TEXT           -- optional tag/cohort label
+  execution_id                    INTEGER PRIMARY KEY,
+  player_class                    TEXT,
+  automated_player_class          TEXT,
+  config_json                     TEXT,
+  log_level                       TEXT,
+  enable_parallelism              TEXT,
+  automated_agent_max_exchanges   INTEGER,
+  scenario                        TEXT,
+  win_threshold                   INTEGER,
+  max_rounds                      INTEGER,
+  roll_success_threshold          INTEGER,
+  notes                           TEXT,
+  created_at                      TEXT DEFAULT CURRENT_TIMESTAMP
 );
 
--- 2) Actions 
+-- 2) Actions recorded for an execution
 CREATE TABLE IF NOT EXISTS actions (
-  action_id           INTEGER PRIMARY KEY,
-  execution_id        INTEGER NOT NULL,              -- FK → executions
-  actor               TEXT,                          -- 'player' or NPC/faction id
-  title               TEXT,                          -- short label shown to player
-  # TODO for Codex: add all field of OptionResponse class
-  option_json     TEXT,                          -- full option payload
+  action_id             INTEGER PRIMARY KEY,
+  execution_id          INTEGER NOT NULL,
+  actor                 TEXT,
+  title                 TEXT,
+  option_text           TEXT,
+  option_type           TEXT,
+  related_triplet       INTEGER,
+  related_attribute     TEXT,
+  success               INTEGER NOT NULL,
+  roll_total            INTEGER,
+  actor_score           INTEGER,
+  player_score          INTEGER,
+  effective_score       INTEGER,
+  credibility_cost      INTEGER,
+  credibility_gain      INTEGER,
+  targets_json          TEXT,
+  failure_text          TEXT,
+  round_number          INTEGER,
+  option_json           TEXT,
+  created_at            TEXT DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (execution_id) REFERENCES executions(execution_id) ON DELETE CASCADE
 );
 
--- 3) Assessments 
+-- 3) Assessments recorded after each action
 CREATE TABLE IF NOT EXISTS assessments (
-  assessment_id       INTEGER PRIMARY KEY,
-  execution_id                INTEGER NOT NULL,      -- FK → executions
-  action_id                   INTEGER NOT NULL,      -- FK → actions
-  scenario    TEXT,
-  # TODO for Codex: dynamically create the columns for each triplet of each faction, present in the scenario yaml.
+  assessment_id         INTEGER PRIMARY KEY,
+  execution_id          INTEGER NOT NULL,
+  action_id             INTEGER NOT NULL,
+  scenario              TEXT,
   final_weighted_score  INTEGER,
+  assessment_json       TEXT,
   FOREIGN KEY (execution_id) REFERENCES executions(execution_id) ON DELETE CASCADE,
   FOREIGN KEY (action_id)    REFERENCES actions(action_id)       ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_outcomes_exec_action ON outcomes(execution_id, action_id);
+CREATE INDEX IF NOT EXISTS idx_assessments_exec_action
+  ON assessments(execution_id, action_id);
 
--- 4) Credibility
+-- 4) Credibility snapshots per action
 CREATE TABLE IF NOT EXISTS credibility (
-  credibility_vector_id       INTEGER PRIMARY KEY,
-  execution_id                INTEGER NOT NULL,      -- FK → executions
-  action_id                   INTEGER NOT NULL,      -- FK → actions
-  cost                   INTEGER NOT NULL,
-  reroll_attempt_count    INTEGER NOT NULL, -- start from 0 as an action without reroll already costs
-  # TODO for Codex: add one column for each relevant credibility matrix element. (e.g. the row of the CivilSociety player). 
+  credibility_vector_id INTEGER PRIMARY KEY,
+  execution_id          INTEGER NOT NULL,
+  action_id             INTEGER NOT NULL,
+  cost                  INTEGER NOT NULL,
+  reroll_attempt_count  INTEGER NOT NULL,
+  credibility_json      TEXT,
+  FOREIGN KEY (execution_id) REFERENCES executions(execution_id) ON DELETE CASCADE,
+  FOREIGN KEY (action_id)    REFERENCES actions(action_id)       ON DELETE CASCADE
+);
+
+-- 5) Results recorded per execution
+CREATE TABLE IF NOT EXISTS results (
+  execution_id          INTEGER PRIMARY KEY,
+  successful_execution  INTEGER NOT NULL,
+  result                TEXT,
+  error_info            TEXT,
+  created_at            TEXT DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (execution_id) REFERENCES executions(execution_id) ON DELETE CASCADE
 );

--- a/tests/test_game_database_recorder.py
+++ b/tests/test_game_database_recorder.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from unittest.mock import MagicMock
+
+from evaluations.game_database import GameDatabaseRecorder
+from evaluations.sqlite3_connector import SQLiteConnector
+from rpg.character import ResponseOption
+from rpg.config import GameConfig
+from rpg.game_state import ActionAttempt
+
+
+class DummyCredibility:
+    def __init__(self, mapping: dict[str, dict[str, int]]) -> None:
+        self._mapping = mapping
+
+    def snapshot(self) -> dict[str, dict[str, int]]:
+        return {source: dict(targets) for source, targets in self._mapping.items()}
+
+
+class DummyPlayerCharacter:
+    faction = "CivilSociety"
+
+
+def _build_state() -> SimpleNamespace:
+    config = GameConfig(scenario="complete", win_threshold=70, max_rounds=8, roll_success_threshold=12)
+    progress = {"Governments": [0, 0], "CivilSociety": [0]}
+    credibility = DummyCredibility({"CivilSociety": {"Governments": 55, "CivilSociety": 100}})
+    state = SimpleNamespace(
+        progress=progress,
+        credibility=credibility,
+        player_faction="CivilSociety",
+        config=config,
+        player_character=DummyPlayerCharacter(),
+        last_action_attempt=None,
+        last_action_actor=None,
+        last_reroll_count=0,
+    )
+    state.final_weighted_score = lambda: 75
+    return state
+
+
+def test_recorder_writes_expected_payloads() -> None:
+    connector = MagicMock(spec=SQLiteConnector)
+    connector.insert_execution.return_value = 3
+    connector.insert_action.return_value = 10
+
+    recorder = GameDatabaseRecorder(connector, notes="test-run")
+    state = _build_state()
+
+    recorder.on_game_start(
+        state,
+        player_key="alpha",
+        player_class="PlayerChar",
+        automated_player_class="AutoPlayer",
+        game_index=1,
+    )
+    connector.ensure_dynamic_schema.assert_called_once()
+    connector.insert_execution.assert_called_once()
+
+    recorder.before_turn(state, 1)
+    state.progress = {"Governments": [20, 30], "CivilSociety": [40]}
+    option = ResponseOption(text="Coordinate", type="action", related_triplet=1, related_attribute="influence")
+    attempt = ActionAttempt(
+        success=True,
+        option=option,
+        label="Action 1",
+        attribute="influence",
+        actor_score=8,
+        player_score=10,
+        effective_score=10,
+        roll=7,
+        targets=("Governments",),
+        credibility_cost=3,
+        credibility_gain=5,
+        failure_text=None,
+    )
+    state.last_action_attempt = attempt
+    state.last_action_actor = "NPC"
+    state.last_reroll_count = 1
+
+    recorder.after_turn(state, 1)
+
+    connector.insert_action.assert_called_once()
+    action_payload = connector.insert_action.call_args.args[0]
+    assert action_payload["round_number"] == 1
+    assert action_payload["success"] == 1
+    assert action_payload["credibility_cost"] == 3
+    assert action_payload["option_type"] == "action"
+
+    connector.insert_assessment.assert_called_once()
+    assessment_payload = connector.insert_assessment.call_args.args[0]
+    assert assessment_payload["final_weighted_score"] == 75
+    assert assessment_payload["governments_triplet_1"] == 20
+    assert assessment_payload["civilsociety_triplet_1"] == 40
+    assert assessment_payload["assessment_json"]["before"] == {"Governments": [0, 0], "CivilSociety": [0]}
+
+    connector.insert_credibility.assert_called_once()
+    credibility_payload = connector.insert_credibility.call_args.args[0]
+    assert credibility_payload["reroll_attempt_count"] == 1
+    assert credibility_payload["credibility_governments"] == 55
+    assert credibility_payload["credibility_civilsociety"] == 100
+
+    recorder.on_game_end(state, result="Win", successful=True, error=None)
+    connector.insert_result.assert_called_once()
+    result_payload = connector.insert_result.call_args.args[0]
+    assert result_payload["execution_id"] == 3
+    assert result_payload["successful_execution"] is True
+    assert result_payload["result"] == "Win"
+    assert connector.commit.call_count >= 2
+
+
+def test_recorder_records_error_outcome() -> None:
+    connector = MagicMock(spec=SQLiteConnector)
+    connector.insert_execution.return_value = 7
+
+    recorder = GameDatabaseRecorder(connector)
+    state = _build_state()
+
+    recorder.on_game_start(
+        state,
+        player_key="beta",
+        player_class="PlayerChar",
+        automated_player_class="AutoPlayer",
+        game_index=2,
+    )
+
+    recorder.on_game_error(state, RuntimeError("boom"))
+
+    connector.insert_result.assert_called_once()
+    result_payload = connector.insert_result.call_args.args[0]
+    assert result_payload["execution_id"] == 7
+    assert result_payload["successful_execution"] is False
+    assert result_payload["result"] == "N/A"
+    assert "boom" in result_payload["error_info"]
+    connector.commit.assert_called()

--- a/tests/test_sqlite_connector.py
+++ b/tests/test_sqlite_connector.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from evaluations.sqlite3_connector import SQLiteConnector
+
+
+def _get_columns(connection: sqlite3.Connection, table: str) -> dict[str, str]:
+    cursor = connection.execute(f"PRAGMA table_info({table})")
+    return {row[1]: row[2] for row in cursor.fetchall()}
+
+
+def test_dynamic_schema_and_inserts(tmp_path: Path) -> None:
+    db_path = tmp_path / "test.sqlite"
+    connector = SQLiteConnector(db_path=db_path)
+    connector.initialise()
+
+    connector.ensure_dynamic_schema({"Governments": 2, "CivilSociety": 1}, ["Governments", "CivilSociety"])
+
+    columns = _get_columns(connector.connection, "assessments")
+    assert "governments_triplet_1" in columns
+    assert "governments_triplet_2" in columns
+    assert "civilsociety_triplet_1" in columns
+
+    credibility_columns = _get_columns(connector.connection, "credibility")
+    assert "credibility_governments" in credibility_columns
+    assert "credibility_civilsociety" in credibility_columns
+
+    execution_id = connector.insert_execution(
+        {
+            "player_class": "TestPlayer",
+            "automated_player_class": "Auto",
+            "scenario": "complete",
+            "win_threshold": 10,
+            "max_rounds": 5,
+            "roll_success_threshold": 10,
+        }
+    )
+    assert execution_id > 0
+
+    action_id = connector.insert_action(
+        {
+            "execution_id": execution_id,
+            "actor": "NPC",
+            "title": "Action",
+            "option_text": "Do something",
+            "option_type": "action",
+            "success": 1,
+            "round_number": 1,
+            "option_json": {"text": "Do something"},
+        }
+    )
+    assert action_id > 0
+
+    assessment_id = connector.insert_assessment(
+        {
+            "execution_id": execution_id,
+            "action_id": action_id,
+            "scenario": "complete",
+            "final_weighted_score": 42,
+            "assessment_json": {"after": {"Governments": {"1": 50}}},
+            "governments_triplet_1": 50,
+            "governments_triplet_2": 20,
+            "civilsociety_triplet_1": 30,
+        }
+    )
+    assert assessment_id > 0
+
+    credibility_id = connector.insert_credibility(
+        {
+            "execution_id": execution_id,
+            "action_id": action_id,
+            "cost": 3,
+            "reroll_attempt_count": 0,
+            "credibility_json": {"CivilSociety": 100},
+            "credibility_civilsociety": 100,
+        }
+    )
+    assert credibility_id > 0
+
+    connector.insert_result(
+        {
+            "execution_id": execution_id,
+            "successful_execution": True,
+            "result": "Win",
+        }
+    )
+    row = connector.connection.execute(
+        "SELECT result, successful_execution FROM results WHERE execution_id = ?",
+        (execution_id,),
+    ).fetchone()
+    assert row["result"] == "Win"
+    assert row["successful_execution"] == 1
+
+    connector.commit()
+    connector.close()


### PR DESCRIPTION
## Summary
- add a results table to the evaluation schema and expose an insert helper on the SQLite connector
- extend the database recorder and player manager observer hooks to capture win/lose/error outcomes
- expand the mocked tests to assert result persistence and error handling

## Testing
- pytest tests/test_sqlite_connector.py tests/test_game_database_recorder.py

------
https://chatgpt.com/codex/tasks/task_e_68f53b2c58d88333ae515bc333e3f039