### PR TITLE
Add action-first automated player strategy

### DIFF
--- a/evaluations/player_game.py
+++ b/evaluations/player_game.py
@@ -14,6 +14,7 @@ from rpg.game_state import GameState
 from rpg.assessment_agent import AssessmentAgent
 
 from .players import (
+    ActionFirstRandomPlayer,
     GeminiCivilSocietyPlayer,
     GeminiCorporationPlayer,
     RandomPlayer,
@@ -28,6 +29,7 @@ def create_players(characters) -> Dict[str, object]:
     )
     return {
         "random": RandomPlayer(),
+        "action-first": ActionFirstRandomPlayer(),
         "civil-society": GeminiCivilSocietyPlayer(),
         "corporation": GeminiCorporationPlayer(corp_ctx),
     }
@@ -40,7 +42,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--player",
-        choices=["random", "civil-society", "corporation"],
+        choices=["random", "action-first", "civil-society", "corporation"],
         default="random",
         help="Which automated player to use",
     )

--- a/evaluations/player_service.py
+++ b/evaluations/player_service.py
@@ -33,6 +33,7 @@ from evaluations.assessment_consistency import run_consistency_assessment
 from evaluations.game_database import GameDatabaseRecorder
 from evaluations.player_manager import PlayerManager
 from evaluations.players import (
+    ActionFirstRandomPlayer,
     GeminiCivilSocietyPlayer,
     GeminiCorporationPlayer,
     Player,
@@ -119,6 +120,7 @@ def create_app(log_dir: str | None = None) -> Flask:
 
     player_choices = [
         ("random", "Random (uniform choice)"),
+        ("action-first", "Action-first opportunist"),
         ("civil-society", "Civil society strategist"),
         ("corporation", "Corporation advocate"),
     ]
@@ -130,6 +132,7 @@ def create_app(log_dir: str | None = None) -> Flask:
         )
         return {
             "random": RandomPlayer(),
+            "action-first": ActionFirstRandomPlayer(),
             "civil-society": GeminiCivilSocietyPlayer(),
             "corporation": GeminiCorporationPlayer(corporation_context),
         }

--- a/evaluations/players.py
+++ b/evaluations/players.py
@@ -254,6 +254,48 @@ class RandomPlayer(Player):
         return decision
 
 
+class ActionFirstRandomPlayer(RandomPlayer):
+    """Random-like player that prioritises taking the first available action."""
+
+    def select_action(
+        self,
+        character: Character,
+        conversation: Sequence[ConversationEntry],
+        actions: List[ResponseOption],
+        state: GameState,
+    ) -> ResponseOption:
+        for option in actions:
+            if option.is_action:
+                logger.info(
+                    "ActionFirstRandomPlayer chose immediate action '%s' for %s",
+                    option.text,
+                    character.name,
+                )
+                return option
+        action = random.choice(actions)
+        logger.info(
+            "ActionFirstRandomPlayer fell back to random dialogue '%s' for %s",
+            action.text,
+            character.name,
+        )
+        return action
+
+    def should_reroll(
+        self,
+        character: Character,
+        conversation: Sequence[ConversationEntry],
+        attempt: ActionAttempt,
+        state: GameState,
+    ) -> bool:
+        cost = state.next_reroll_cost(character, attempt.option)
+        logger.info(
+            "ActionFirstRandomPlayer reroll decision for %s (cost=%d): yes",
+            character.name,
+            cost,
+        )
+        return True
+
+
 class GeminiCivilSocietyPlayer(Player):
     """Gemini-based player using the civil society victory guide."""
 

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -93,7 +93,7 @@ class PlayerServiceTest(unittest.TestCase):
 
                 resp = client.post(
                     "/",
-                    data={"player": "random", "rounds": "1", "games": "2"},
+                    data={"player": "action-first", "rounds": "1", "games": "2"},
                     follow_redirects=True,
                 )
                 page = resp.data.decode()
@@ -102,6 +102,7 @@ class PlayerServiceTest(unittest.TestCase):
                 self.assertIn("Game 2", page)
                 self.assertIn("10, 20, 30", page)
                 self.assertIn("Download log", page)
+                self.assertIn("Selected player: action-first", page)
                 log_links = re.findall(r"/logs/([^\"']+)", page)
                 self.assertGreaterEqual(len(log_links), 2)
                 log_resp = client.get(f"/logs/{log_links[0]}")
@@ -121,6 +122,7 @@ class PlayerServiceTest(unittest.TestCase):
         page = resp.data.decode()
         self.assertIn("Baseline Assessment", page)
         self.assertIn("Consistency Assessment", page)
+        self.assertIn("Action-first opportunist", page)
 
 
 if __name__ == "__main__":

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -11,6 +11,7 @@ import yaml
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from evaluations.players import (
+    ActionFirstRandomPlayer,
     GeminiCivilSocietyPlayer,
     GeminiCorporationPlayer,
     RandomPlayer,
@@ -82,6 +83,9 @@ class PlayerTests(unittest.TestCase):
         def choice_side_effect(options):
             if options and isinstance(options[0], YamlCharacter):
                 return char
+            for option in options:
+                if getattr(option, "is_action", False):
+                    return option
             return options[0]
 
         mock_choice.side_effect = choice_side_effect
@@ -94,6 +98,58 @@ class PlayerTests(unittest.TestCase):
         self.assertEqual(state.progress[char.progress_key], [10, 20, 30])
         self.assertIsNotNone(state.last_action_attempt)
         self.assertEqual(state.last_action_attempt.attribute, "leadership")
+
+    @patch("evaluations.players.random.choice")
+    @patch("rpg.assessment_agent.genai")
+    @patch("rpg.character.genai")
+    @patch("rpg.game_state.random.randint", side_effect=[1, 20])
+    def test_action_first_player_rerolls_until_success(
+        self, mock_uniform, mock_char_genai, mock_assess_genai, mock_choice
+    ):
+        mock_action_model = MagicMock()
+        mock_assess_model = MagicMock()
+        mock_action_model.generate_content.return_value = MagicMock(
+            text=json.dumps(
+                [
+                    {
+                        "text": "Discuss", "type": "chat", "related-triplet": "None"
+                    },
+                    {
+                        "text": "A",
+                        "type": "action",
+                        "related-triplet": 1,
+                        "related-attribute": "leadership",
+                    },
+                ]
+            )
+        )
+        mock_assess_model.generate_content.return_value = MagicMock(
+            text="10\n20\n30"
+        )
+        mock_char_genai.GenerativeModel.return_value = mock_action_model
+        mock_assess_genai.GenerativeModel.return_value = mock_assess_model
+        char = _load_test_character()
+        state = GameState([char])
+        assessor = AssessmentAgent()
+
+        def choice_side_effect(options):
+            if options and isinstance(options[0], YamlCharacter):
+                return char
+            for option in options:
+                if getattr(option, "is_action", False):
+                    return option
+            return options[0]
+
+        mock_choice.side_effect = choice_side_effect
+        player = ActionFirstRandomPlayer()
+        player.take_turn(state, assessor)
+
+        self.assertEqual(state.history[0], (char.display_name, "A"))
+        self.assertEqual(state.progress[char.progress_key], [10, 20, 30])
+        self.assertIsNotNone(state.last_action_attempt)
+        self.assertTrue(state.last_action_attempt.success)
+        self.assertEqual(state.last_reroll_count, 1)
+        self.assertEqual(mock_uniform.call_count, 2)
 
     @patch("evaluations.players.genai")
     @patch("rpg.character.genai")
@@ -110,7 +166,7 @@ class PlayerTests(unittest.TestCase):
             ResponseOption(text="B", type="action"),
             ResponseOption(text="C", type="action"),
         ]
-        player.select_action(char, actions, state)
+        player.select_action(char, [], actions, state)
         prompt = mock_model.generate_content.call_args[0][0]
         self.assertIn(state.how_to_win.split()[0], prompt)
         self.assertIn(char.display_name, prompt)
@@ -131,7 +187,7 @@ class PlayerTests(unittest.TestCase):
             ResponseOption(text="B", type="action"),
             ResponseOption(text="C", type="action"),
         ]
-        player.select_action(char, actions, state)
+        player.select_action(char, [], actions, state)
         prompt = mock_model.generate_content.call_args[0][0]
         self.assertIn("CTX", prompt)
 


### PR DESCRIPTION
## Summary
- add an action-first automated player that takes the first available action and rerolls until it succeeds
- expose the new player option through the CLI helper and evaluation web service
- exercise the new strategy and UI choice with dedicated unit tests

## Testing
- pytest tests/test_players.py tests/test_player_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f7e7e053188333b683f3af3c9f8610