### PR TITLE
Support batch automated player runs in service

### DIFF
--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -90,12 +90,16 @@ class PlayerServiceTest(unittest.TestCase):
                     with patch("rpg.game_state.random.randint", return_value=20):
                         app = create_app(log_dir=tmpdir)
                         client = app.test_client()
+                        resp = client.post(
+                            "/",
+                            data={
+                                "player": "action-first",
+                                "rounds": "1",
+                                "games": "2",
+                            },
+                            follow_redirects=True,
+                        )
 
-                resp = client.post(
-                    "/",
-                    data={"player": "action-first", "rounds": "1", "games": "2"},
-                    follow_redirects=True,
-                )
                 page = resp.data.decode()
                 self.assertIn("Player Manager Progress", page)
                 self.assertIn("Game 1", page)
@@ -123,6 +127,95 @@ class PlayerServiceTest(unittest.TestCase):
         self.assertIn("Baseline Assessment", page)
         self.assertIn("Consistency Assessment", page)
         self.assertIn("Action-first opportunist", page)
+
+    def test_batch_runs_execute_multiple_configurations(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("evaluations.players.random.choice") as mock_choice, patch(
+                "rpg.character.genai"
+            ) as mock_char_genai, patch(
+                "rpg.assessment_agent.genai"
+            ) as mock_assess_genai, patch(
+                "evaluations.players.genai"
+            ) as mock_players_genai:
+                mock_action_model = MagicMock()
+                mock_assess_model = MagicMock()
+                mock_action_model.generate_content.return_value = MagicMock(
+                    text=json.dumps(
+                        [
+                            {
+                                "text": "A",
+                                "type": "action",
+                                "related-triplet": 1,
+                                "related-attribute": "leadership",
+                            },
+                            {
+                                "text": "B",
+                                "type": "action",
+                                "related-triplet": "None",
+                                "related-attribute": "technology",
+                            },
+                            {
+                                "text": "C",
+                                "type": "action",
+                                "related-triplet": "None",
+                                "related-attribute": "policy",
+                            },
+                        ]
+                    )
+                )
+                mock_assess_model.generate_content.return_value = MagicMock(
+                    text="10\n20\n30"
+                )
+                mock_char_genai.GenerativeModel.return_value = mock_action_model
+                mock_assess_genai.GenerativeModel.return_value = mock_assess_model
+                mock_players_genai.GenerativeModel.return_value = MagicMock()
+                character = _load_test_character()
+
+                def choice_side_effect(options):
+                    if options and isinstance(options[0], YamlCharacter):
+                        return character
+                    return options[0]
+
+                mock_choice.side_effect = choice_side_effect
+                with patch(
+                    "evaluations.player_service.load_characters",
+                    return_value=[character],
+                ) as mock_load_characters:
+                    with patch("rpg.game_state.random.randint", return_value=20):
+                        app = create_app(log_dir=tmpdir)
+                        client = app.test_client()
+                        batch_payload = json.dumps(
+                            [
+                                {
+                                    "player": "action-first",
+                                    "rounds": 1,
+                                    "games": 1,
+                                    "scenario": "complete",
+                                },
+                                {
+                                    "player": "random",
+                                    "rounds": 1,
+                                    "games": 1,
+                                    "scenario": "complete",
+                                    "player_config": {"label": "second"},
+                                },
+                            ]
+                        )
+                        resp = client.post(
+                            "/",
+                            data={"batch_runs": batch_payload},
+                            follow_redirects=True,
+                        )
+
+                self.assertEqual(mock_load_characters.call_count, 2)
+                page = resp.data.decode()
+                self.assertIn("Total configured runs: 2", page)
+                self.assertIn("Run 1", page)
+                self.assertIn("Run 2", page)
+                self.assertIn("Selected player: action-first", page)
+                self.assertIn("Selected player: random", page)
+                self.assertIn("Player configuration: Default", page)
+                self.assertIn("Player configuration: {\"label\": \"second\"}", page)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow the player service to execute multiple scenario/player/player_config combinations in one submission
- update the UI to accept batch JSON, persist player configuration choices, and render multi-run progress summaries
- extend the player service tests to cover the new batch execution path and updated progress output

## Testing
- pytest tests/test_player_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f7f13cb9248333bc4ea9a9dfba5be0