### PR TITLE
Fix Gemini cache creation by setting content roles

### DIFF
--- a/rpg/genai_cache.py
+++ b/rpg/genai_cache.py
@@ -95,11 +95,12 @@ class GeminiCacheManager:
     def _format_ttl(seconds: int) -> str:
         return f"{max(1, seconds)}s"
 
-    def _text_to_content(self, text: str):
+    def _text_to_content(self, text: str, role: str = "user"):
         """Return a ``types.Content`` instance for ``text``."""
 
         return google_genai_types.Content(
-            parts=[google_genai_types.Part.from_text(text=text)]
+            role=role,
+            parts=[google_genai_types.Part.from_text(text=text)],
         )
 
     def _find_existing_cache(self, display_name: str):
@@ -117,6 +118,7 @@ class GeminiCacheManager:
         display_name: str,
         model: str,
         texts: Iterable[str],
+        content_role: str = "user",
         system_instruction: str | None = None,
     ) -> Optional[object]:
         """Return a ``GenerateContentConfig`` referencing cached ``texts``.
@@ -130,7 +132,9 @@ class GeminiCacheManager:
         filtered: List[str] = [part.strip() for part in texts if str(part).strip()]
         if not filtered:
             return None
-        contents = [self._text_to_content(text) for text in filtered]
+        contents = [
+            self._text_to_content(text, role=content_role) for text in filtered
+        ]
         with self._lock:
             cache_name = self._cache_names.get(display_name)
             if not cache_name:

--- a/tests/test_genai_cache_manager.py
+++ b/tests/test_genai_cache_manager.py
@@ -3,7 +3,7 @@
 import os
 from types import SimpleNamespace
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from rpg.genai_cache import GeminiCacheManager
 
@@ -37,6 +37,13 @@ class GeminiCacheManagerTest(TestCase):
             texts=["alpha", "beta"],
         )
         self.assertEqual(config, {"generate": {"cached_content": "cached/1"}})
+        self.assertEqual(
+            [call.kwargs for call in mock_types.Content.call_args_list],
+            [
+                {"role": "user", "parts": [{"text": "alpha"}]},
+                {"role": "user", "parts": [{"text": "beta"}]},
+            ],
+        )
         mock_client.caches.create.assert_called_once()
         mock_client.caches.update.assert_not_called()
 


### PR DESCRIPTION
## Summary
- ensure cached content entries include a user role so Gemini accepts cache creation
- cover the role requirement with unit tests for the cache manager

## Testing
- PYTHONPATH=. pytest tests/test_genai_cache_manager.py
- PYTHONPATH=. pytest tests/test_character.py tests/test_character_fallback.py tests/test_credibility.py tests/test_game_database_recorder.py tests/test_game_state.py

------
https://chatgpt.com/codex/tasks/task_e_690bc3f99fb88333a7cb6d24917b4909