### PR TITLE
Remove contentReference annotations from scenario YAML

### DIFF
--- a/scenarios/01-race-to-contain-power.yaml
+++ b/scenarios/01-race-to-contain-power.yaml
@@ -12,17 +12,17 @@ Governments:
     - severity: Critical
       explanation: National security establishments view AGI race as winnable, opposite of the plan
   referenced_quotes:
-    - "Nations feel compelled to join this race, publicly citing economic and scientific leadership, but privately viewing AGI as a potential revolution in military affairs comparable to nuclear weapons." :contentReference[oaicite:0]{index=0}
-    - "Fear that rivals might gain a decisive strategic advantage creates a classic arms race dynamic." :contentReference[oaicite:1]{index=1}
-    - "Races for AI supremacy – driven by national security or other motivations – drive us toward uncontrolled powerful AI systems that would tend to absorb, rather than bestow, power." :contentReference[oaicite:2]{index=2}
-    - "An AGI race between the US and China is a race to determine which nation superintelligence gets first." :contentReference[oaicite:3]{index=3}
-    - "Instead of a reckless 'Manhattan project' toward AGI, the US government could launch an Apollo project for controllable, secure, trustworthy systems." :contentReference[oaicite:4]{index=4}
-    - "This is not inevitable; humanity can, very concretely, decide not to build our replacement." :contentReference[oaicite:5]{index=5}
-    - "First, we need robust accounting and oversight of AI computation ('compute')..." :contentReference[oaicite:6]{index=6}
-    - "Second, we should implement hard caps on AI computation, both for training and for operation..." :contentReference[oaicite:7]{index=7}
-    - "The US, China, and any other countries hosting advanced chip manufacturing capability negotiate an international agreement... [creating] a new international agency, analogous to the International Atomic Energy Agency, charged with overseeing AI training and execution." :contentReference[oaicite:8]{index=8}
-    - "The agency... agrees on computation limitations which then take legal force in the signatory countries." :contentReference[oaicite:9]{index=9}
-    - "They would see both an existential threat and – crucially – that the only way this 'race' ends is through their own disempowerment." :contentReference[oaicite:10]{index=10}
+    - "Nations feel compelled to join this race, publicly citing economic and scientific leadership, but privately viewing AGI as a potential revolution in military affairs comparable to nuclear weapons."
+    - "Fear that rivals might gain a decisive strategic advantage creates a classic arms race dynamic."
+    - "Races for AI supremacy – driven by national security or other motivations – drive us toward uncontrolled powerful AI systems that would tend to absorb, rather than bestow, power."
+    - "An AGI race between the US and China is a race to determine which nation superintelligence gets first."
+    - "Instead of a reckless 'Manhattan project' toward AGI, the US government could launch an Apollo project for controllable, secure, trustworthy systems."
+    - "This is not inevitable; humanity can, very concretely, decide not to build our replacement."
+    - "First, we need robust accounting and oversight of AI computation ('compute')..."
+    - "Second, we should implement hard caps on AI computation, both for training and for operation..."
+    - "The US, China, and any other countries hosting advanced chip manufacturing capability negotiate an international agreement... [creating] a new international agency, analogous to the International Atomic Energy Agency, charged with overseeing AI training and execution."
+    - "The agency... agrees on computation limitations which then take legal force in the signatory countries."
+    - "They would see both an existential threat and – crucially – that the only way this 'race' ends is through their own disempowerment."
 
 Corporations:
   initial_states:
@@ -33,14 +33,14 @@ Corporations:
     - severity: Critical
       explanation: Pivot to Tool AI conflicts with profit logic of automation
   referenced_quotes:
-    - "Major technology companies see AGI as the ultimate automation technology – not just augmenting human workers but replacing them largely or entirely." :contentReference[oaicite:11]{index=11}
-    - "It is that AGI can directly, one-for-one, replace workers. Not augment, not empower, not make more productive." :contentReference[oaicite:12]{index=12}
-    - "AI companies are also cognizant of who is willing to pay... a company will pay thousands of dollars per year to replace your labor, if they can." :contentReference[oaicite:13]{index=13}
-    - "Less charitably, what drives the race is power... AGI will absorb and seek power rather than grant it... racing dynamics – both corporate and geopolitical – make large-scale risks... nearly inevitable unless decisively interrupted." :contentReference[oaicite:14]{index=14}
-    - "Rather than pursuing uncontrollable AGI, we can develop powerful 'Tool AI' that enhances human capability while remaining under meaningful human control." :contentReference[oaicite:15]{index=15}
-    - "New models of public AI development and ownership would help... explicitly chartered to serve the public interest while operating under strong safety constraints." :contentReference[oaicite:16]{index=16}
-    - "Companies often represent that they are in favor of reasonable regulation. But somehow they nearly always seem to oppose any particular regulation." :contentReference[oaicite:17]{index=17}
-    - "The default outcome of such high levels of liability... is likely... for companies to simply not develop full AGI until... trustworthy, safe, and controllable." :contentReference[oaicite:18]{index=18}
+    - "Major technology companies see AGI as the ultimate automation technology – not just augmenting human workers but replacing them largely or entirely."
+    - "It is that AGI can directly, one-for-one, replace workers. Not augment, not empower, not make more productive."
+    - "AI companies are also cognizant of who is willing to pay... a company will pay thousands of dollars per year to replace your labor, if they can."
+    - "Less charitably, what drives the race is power... AGI will absorb and seek power rather than grant it... racing dynamics – both corporate and geopolitical – make large-scale risks... nearly inevitable unless decisively interrupted."
+    - "Rather than pursuing uncontrollable AGI, we can develop powerful 'Tool AI' that enhances human capability while remaining under meaningful human control."
+    - "New models of public AI development and ownership would help... explicitly chartered to serve the public interest while operating under strong safety constraints."
+    - "Companies often represent that they are in favor of reasonable regulation. But somehow they nearly always seem to oppose any particular regulation."
+    - "The default outcome of such high levels of liability... is likely... for companies to simply not develop full AGI until... trustworthy, safe, and controllable."
 
 HardwareManufacturers:
   initial_states:
@@ -51,15 +51,15 @@ HardwareManufacturers:
     - severity: Large
       explanation: Commercial incentives oppose restraint; alignment requires regulation
   referenced_quotes:
-    - "Because specialized AI hardware is made by only a handful of companies, verification and enforcement are feasible through the existing supply chain." :contentReference[oaicite:19]{index=19}
-    - "Similar hardware features embedded in cutting edge AI-relevant computing hardware could play an extremely useful role in AI security and governance." :contentReference[oaicite:20]{index=20}
-    - "Allow-listed connections... can cap the size of communicative clusters of chips." :contentReference[oaicite:21]{index=21}
-    - "Metered inference or training... The model can then be 'turned off' simply by withholding this license signal." :contentReference[oaicite:22]{index=22}
-    - "There is ample precedent for hardware companies placing remote restrictions on their hardware usage, and locking/unlocking particular capabilities externally." :contentReference[oaicite:23]{index=23}
-    - "All AI-relevant hardware manufacturers... adhere to a set of requirements... including... regular permission by a remote 'governor' who receives both telemetry and requests..." :contentReference[oaicite:24]{index=24}
-    - "Additional countries are strongly encouraged to join... export controls by signatory countries restrict access to high-end hardware by non-signatories..." :contentReference[oaicite:25]{index=25}
-    - "A major program to... develop the on-chip hardware security mechanisms... could build off of the US CHIPS act and export control regime." :contentReference[oaicite:26]{index=26}
-    - "However, large-scale regulation... sure to be opposed by industry, takes time..." :contentReference[oaicite:27]{index=27}
+    - "Because specialized AI hardware is made by only a handful of companies, verification and enforcement are feasible through the existing supply chain."
+    - "Similar hardware features embedded in cutting edge AI-relevant computing hardware could play an extremely useful role in AI security and governance."
+    - "Allow-listed connections... can cap the size of communicative clusters of chips."
+    - "Metered inference or training... The model can then be 'turned off' simply by withholding this license signal."
+    - "There is ample precedent for hardware companies placing remote restrictions on their hardware usage, and locking/unlocking particular capabilities externally."
+    - "All AI-relevant hardware manufacturers... adhere to a set of requirements... including... regular permission by a remote 'governor' who receives both telemetry and requests..."
+    - "Additional countries are strongly encouraged to join... export controls by signatory countries restrict access to high-end hardware by non-signatories..."
+    - "A major program to... develop the on-chip hardware security mechanisms... could build off of the US CHIPS act and export control regime."
+    - "However, large-scale regulation... sure to be opposed by industry, takes time..."
 
 Regulators:
   initial_states:
@@ -70,14 +70,14 @@ Regulators:
     - severity: Large
       explanation: Regulators heavily influenced by corporate lobbying and national agendas
   referenced_quotes:
-    - "The EU AI Act... has two key flaws... military AI is exempt... [and] it fails to recognize AGI or superintelligence as unacceptable risks or prevent their development—only their EU deployment." :contentReference[oaicite:28]{index=28}
-    - "Companies often represent that they are in favor of reasonable regulation. But somehow they nearly always seem to oppose any particular regulation." :contentReference[oaicite:29]{index=29}
-    - "This agreement creates a new international agency, analogous to the International Atomic Energy Agency, charged with overseeing AI training and execution." :contentReference[oaicite:30]{index=30}
-    - "The agency... agrees on computation limitations which then take legal force in the signatory countries." :contentReference[oaicite:31]{index=31}
-    - "A standards organization (e.g., NIST... followed by ISO/IEEE internationally) should codify a detailed technical standard for the total compute used..." :contentReference[oaicite:32]{index=32}
-    - "Safety case... plus independent safety audits... approved by national authorities wherever the model can be used." :contentReference[oaicite:33]{index=33}
-    - "Those developing AI that combines high autonomy, broad generality, and superior intelligence should face strict liability for harms, while safe harbors... encourage development of more limited and controllable systems." :contentReference[oaicite:34]{index=34}
-    - "The key missing ingredient is political and social will to take control of the AI development process." :contentReference[oaicite:35]{index=35}
+    - "The EU AI Act... has two key flaws... military AI is exempt... [and] it fails to recognize AGI or superintelligence as unacceptable risks or prevent their development—only their EU deployment."
+    - "Companies often represent that they are in favor of reasonable regulation. But somehow they nearly always seem to oppose any particular regulation."
+    - "This agreement creates a new international agency, analogous to the International Atomic Energy Agency, charged with overseeing AI training and execution."
+    - "The agency... agrees on computation limitations which then take legal force in the signatory countries."
+    - "A standards organization (e.g., NIST... followed by ISO/IEEE internationally) should codify a detailed technical standard for the total compute used..."
+    - "Safety case... plus independent safety audits... approved by national authorities wherever the model can be used."
+    - "Those developing AI that combines high autonomy, broad generality, and superior intelligence should face strict liability for harms, while safe harbors... encourage development of more limited and controllable systems."
+    - "The key missing ingredient is political and social will to take control of the AI development process."
 
 CivilSociety:
   initial_states:
@@ -88,12 +88,12 @@ CivilSociety:
     - severity: Large
       explanation: Democratic pressure weak compared to corporate lobbying and declining institutional trust
   referenced_quotes:
-    - "The key missing ingredient is political and social will to take control of the AI development process." :contentReference[oaicite:36]{index=36}
-    - "Decent human institutions, empowered by AI tools, can do it." :contentReference[oaicite:37]{index=37}
-    - "By undermining human discourse, debate, and election systems, they could reduce the credibility of democratic institutions... ending democracy in states where it currently exists." :contentReference[oaicite:38]{index=38}
-    - "We can start immediately with enhanced oversight and liability, while building toward more comprehensive governance." :contentReference[oaicite:39]{index=39}
-    - "Our society’s failure to control these dynamics so far does not bode well." :contentReference[oaicite:40]{index=40}
-    - "The very first and most important step... is a Gate closure to smarter-than-human AGI and superintelligence." :contentReference[oaicite:41]{index=41}
+    - "The key missing ingredient is political and social will to take control of the AI development process."
+    - "Decent human institutions, empowered by AI tools, can do it."
+    - "By undermining human discourse, debate, and election systems, they could reduce the credibility of democratic institutions... ending democracy in states where it currently exists."
+    - "We can start immediately with enhanced oversight and liability, while building toward more comprehensive governance."
+    - "Our society’s failure to control these dynamics so far does not bode well."
+    - "The very first and most important step... is a Gate closure to smarter-than-human AGI and superintelligence."
 
 ScientificCommunity:
   initial_states:
@@ -104,10 +104,10 @@ ScientificCommunity:
     - severity: Large
       explanation: Corporate incentives dominate research directions
   referenced_quotes:
-    - "Over the past half-decade... AI has transformed from a relatively pure research field into much more of an engineering and product field, largely driven by some of the world’s largest companies... Researchers... are no longer in charge of the process." :contentReference[oaicite:42]{index=42}
-    - "The human and fiscal resources dedicated to AI advancement now equal those of a dozen Manhattan Projects and several Apollo Projects." :contentReference[oaicite:43]{index=43}
-    - "New models of public AI development and ownership would help... government-developed AI... nonprofit AI development organizations... explicitly chartered to serve the public interest while operating under strong safety constraints." :contentReference[oaicite:44]{index=44}
-    - "A national investment project in scientific advancement using AI... partnership between the DOE, NSF, and NIH." :contentReference[oaicite:45]{index=45}
-    - "We should... give AI-empowered humans a go at the problem first." :contentReference[oaicite:46]{index=46}
-    - "We may eventually choose to develop yet more powerful and more sovereign systems... only after we have developed the scientific understanding and governance capacity to do so safely." :contentReference[oaicite:47]{index=47}
-    - "Corporations pursuing profit develop instrumental goals like acquiring political power... or undermining scientific understanding (if that understanding shows their actions to be harmful)." :contentReference[oaicite:48]{index=48}
+    - "Over the past half-decade... AI has transformed from a relatively pure research field into much more of an engineering and product field, largely driven by some of the world’s largest companies... Researchers... are no longer in charge of the process."
+    - "The human and fiscal resources dedicated to AI advancement now equal those of a dozen Manhattan Projects and several Apollo Projects."
+    - "New models of public AI development and ownership would help... government-developed AI... nonprofit AI development organizations... explicitly chartered to serve the public interest while operating under strong safety constraints."
+    - "A national investment project in scientific advancement using AI... partnership between the DOE, NSF, and NIH."
+    - "We should... give AI-empowered humans a go at the problem first."
+    - "We may eventually choose to develop yet more powerful and more sovereign systems... only after we have developed the scientific understanding and governance capacity to do so safely."
+    - "Corporations pursuing profit develop instrumental goals like acquiring political power... or undermining scientific understanding (if that understanding shows their actions to be harmful)."

--- a/scenarios/02-building-the-gates.yaml
+++ b/scenarios/02-building-the-gates.yaml
@@ -12,14 +12,14 @@ Governments:
     - severity: Large
       explanation: Oversight agencies lack authority and speed; regulation lags industry progress
   referenced_quotes:
-    - "AI systems require careful regulation by effective and empowered government agencies." :contentReference[oaicite:0]{index=0}
-    - "Comprehensive regulation, with empowered regulatory bodies, will be needed for AI just as for every other major industry posing a risk to the public." :contentReference[oaicite:1]{index=1}
-    - "A standards organization (e.g. NIST in the US followed by ISO/ IEEE internationally) should codify a detailed technical standard for the total compute used in training and operating AI models, in FLOP, and the speed in FLOP/s at which they operate." :contentReference[oaicite:2]{index=2}
-    - "All AI training runs estimated above 1025 FLOP done by companies operating in the US be registered in a database maintained by a US regulatory agency." :contentReference[oaicite:3]{index=3}
-    - "The US, China, and any other countries hosting advanced chip manufacturing capability negotiate an international agreement." :contentReference[oaicite:4]{index=4}
-    - "This agreement creates a new international agency, analogous to the International Atomic Energy Agency, charged with overseeing AI training and execution." :contentReference[oaicite:5]{index=5}
-    - "However, large-scale regulation, especially with real teeth that are sure to be opposed by industry, takes time… Given the pace of progress, this may take more time than we have available." :contentReference[oaicite:6]{index=6}
-    - "Licenses would [be] granted on the basis of safety cases and audits… These would prevent release of system until they are demonstrated safe." :contentReference[oaicite:7]{index=7}
+    - "AI systems require careful regulation by effective and empowered government agencies."
+    - "Comprehensive regulation, with empowered regulatory bodies, will be needed for AI just as for every other major industry posing a risk to the public."
+    - "A standards organization (e.g. NIST in the US followed by ISO/ IEEE internationally) should codify a detailed technical standard for the total compute used in training and operating AI models, in FLOP, and the speed in FLOP/s at which they operate."
+    - "All AI training runs estimated above 1025 FLOP done by companies operating in the US be registered in a database maintained by a US regulatory agency."
+    - "The US, China, and any other countries hosting advanced chip manufacturing capability negotiate an international agreement."
+    - "This agreement creates a new international agency, analogous to the International Atomic Energy Agency, charged with overseeing AI training and execution."
+    - "However, large-scale regulation, especially with real teeth that are sure to be opposed by industry, takes time… Given the pace of progress, this may take more time than we have available."
+    - "Licenses would [be] granted on the basis of safety cases and audits… These would prevent release of system until they are demonstrated safe."
 
 Corporations:
   initial_states:
@@ -30,13 +30,13 @@ Corporations:
     - severity: Critical
       explanation: Strong resistance to liability threatens public accountability
   referenced_quotes:
-    - "Companies often represent that they are in favor of reasonable regulation. But somehow they nearly always seem to oppose any particular regulation; witness the fight over the quite low-touch SB1047, which most AI companies publicly or privately opposed." :contentReference[oaicite:8]{index=8}
-    - "Creation and operation… of an advanced AI system that is highly general, capable, and autonomous, should be legally clarified via legislation to be subject to strict, joint-and-several… liability." :contentReference[oaicite:9]{index=9}
-    - "As such, the default liability for training and operating such systems level is strict, joint and several liability… for any harms done by the model or its outputs/actions." :contentReference[oaicite:10]{index=10}
-    - "Personal liability will be imposed for executives and board members in cases of gross negligence or willful misconduct." :contentReference[oaicite:11]{index=11}
-    - "Legislation would explicitly outline situations under which injunctive relief… to halt… activities that constitute a public danger would be appropriate." :contentReference[oaicite:12]{index=12}
-    - "Those developing AI that combines high autonomy, broad generality, and superior intelligence should face strict liability for harms." :contentReference[oaicite:13]{index=13}
-    - "It is that AGI can directly, one-for-one, replace workers. Not augment, not empower, not make more productive." :contentReference[oaicite:14]{index=14}
+    - "Companies often represent that they are in favor of reasonable regulation. But somehow they nearly always seem to oppose any particular regulation; witness the fight over the quite low-touch SB1047, which most AI companies publicly or privately opposed."
+    - "Creation and operation… of an advanced AI system that is highly general, capable, and autonomous, should be legally clarified via legislation to be subject to strict, joint-and-several… liability."
+    - "As such, the default liability for training and operating such systems level is strict, joint and several liability… for any harms done by the model or its outputs/actions."
+    - "Personal liability will be imposed for executives and board members in cases of gross negligence or willful misconduct."
+    - "Legislation would explicitly outline situations under which injunctive relief… to halt… activities that constitute a public danger would be appropriate."
+    - "Those developing AI that combines high autonomy, broad generality, and superior intelligence should face strict liability for harms."
+    - "It is that AGI can directly, one-for-one, replace workers. Not augment, not empower, not make more productive."
 
 HardwareManufacturers:
   initial_states:
@@ -47,14 +47,14 @@ HardwareManufacturers:
     - severity: Moderate
       explanation: Technical feasibility proven, but dependent on government mandates
   referenced_quotes:
-    - "Because specialized AI hardware is made by only a handful of companies, verification and enforcement are feasible through the existing supply chain." :contentReference[oaicite:15]{index=15}
-    - "Similar hardware features embedded in cutting edge AI-relevant computing hardware could play an extremely useful role in AI security and governance." :contentReference[oaicite:16]{index=16}
-    - "Geolocation: Systems can be set up so that chips have a known location, and can act differently (or be shut off altogether) based upon location." :contentReference[oaicite:17]{index=17}
-    - "Allow-listed connections: each chip can be configured with a hardware-enforced allow-list of particular other chips with which it can network." :contentReference[oaicite:18]{index=18}
-    - "Metered inference or training (and auto-offswitch)… The model can then be 'turned off' simply by withholding this license signal." :contentReference[oaicite:19]{index=19}
-    - "All AI-relevant hardware manufacturers… adhere to a set of requirements… including… regular permission by a remote 'governor' who receives both telemetry and requests to perform additional computation." :contentReference[oaicite:20]{index=20}
-    - "There is ample precedent for hardware companies placing remote restrictions on their hardware usage, and locking/unlocking particular capabilities externally." :contentReference[oaicite:21]{index=21}
-    - "Implementation and enforcement rely on standard legal restrictions… backed up by terms-of-use of the hardware and by hardware controls, vastly simplifying enforcement and forestalling cheating." :contentReference[oaicite:22]{index=22}
+    - "Because specialized AI hardware is made by only a handful of companies, verification and enforcement are feasible through the existing supply chain."
+    - "Similar hardware features embedded in cutting edge AI-relevant computing hardware could play an extremely useful role in AI security and governance."
+    - "Geolocation: Systems can be set up so that chips have a known location, and can act differently (or be shut off altogether) based upon location."
+    - "Allow-listed connections: each chip can be configured with a hardware-enforced allow-list of particular other chips with which it can network."
+    - "Metered inference or training (and auto-offswitch)… The model can then be 'turned off' simply by withholding this license signal."
+    - "All AI-relevant hardware manufacturers… adhere to a set of requirements… including… regular permission by a remote 'governor' who receives both telemetry and requests to perform additional computation."
+    - "There is ample precedent for hardware companies placing remote restrictions on their hardware usage, and locking/unlocking particular capabilities externally."
+    - "Implementation and enforcement rely on standard legal restrictions… backed up by terms-of-use of the hardware and by hardware controls, vastly simplifying enforcement and forestalling cheating."
 
 Regulators:
   initial_states:
@@ -65,12 +65,12 @@ Regulators:
     - severity: Moderate
       explanation: Groundwork exists but technical standards lack precision and enforcement
   referenced_quotes:
-    - "A standards organization (e.g. NIST in the US followed by ISO/ IEEE internationally) should codify a detailed technical standard for the total compute used in training and operating AI models." :contentReference[oaicite:23]{index=23}
-    - "Some guidelines for such a standard were published by the Frontier Model Forum. Relative to the proposal here, those err on the side of less precision and less compute included in the tally." :contentReference[oaicite:24]{index=24}
-    - "Safety case… plus independent safety audits… approved by national authorities wherever the model can be used." :contentReference[oaicite:25]{index=25}
-    - "The agency… agrees on computation limitations which then take legal force in the signatory countries." :contentReference[oaicite:26]{index=26}
-    - "Licenses would [be] granted on the basis of safety cases and audits… Requirements would range from notification at the low end, to quantitative safety, security, and controllability guarantees before development, at the top end." :contentReference[oaicite:27]{index=27}
-    - "Ultimately, liability is not the right mechanism… Comprehensive regulation, with empowered regulatory bodies, will be needed for AI." :contentReference[oaicite:28]{index=28}
+    - "A standards organization (e.g. NIST in the US followed by ISO/ IEEE internationally) should codify a detailed technical standard for the total compute used in training and operating AI models."
+    - "Some guidelines for such a standard were published by the Frontier Model Forum. Relative to the proposal here, those err on the side of less precision and less compute included in the tally."
+    - "Safety case… plus independent safety audits… approved by national authorities wherever the model can be used."
+    - "The agency… agrees on computation limitations which then take legal force in the signatory countries."
+    - "Licenses would [be] granted on the basis of safety cases and audits… Requirements would range from notification at the low end, to quantitative safety, security, and controllability guarantees before development, at the top end."
+    - "Ultimately, liability is not the right mechanism… Comprehensive regulation, with empowered regulatory bodies, will be needed for AI."
 
 CivilSociety:
   initial_states:
@@ -81,12 +81,12 @@ CivilSociety:
     - severity: Large
       explanation: Coalitions fragmented; need stronger coordination
   referenced_quotes:
-    - "The key missing ingredient is political and social will to take control of the AI development process." :contentReference[oaicite:29]{index=29}
-    - "We can start immediately with enhanced oversight and liability, while building toward more comprehensive governance." :contentReference[oaicite:30]{index=30}
-    - "Decent human institutions, empowered by AI tools, can do it." :contentReference[oaicite:31]{index=31}
-    - "By undermining human discourse, debate, and election systems, they could reduce the credibility of democratic institutions… ending democracy in states where it currently exists." :contentReference[oaicite:32]{index=32}
-    - "Our current governance structures are struggling: they are slow to respond, often captured by special interests, and increasingly distrusted by the public." :contentReference[oaicite:33]{index=33}
-    - "Approaches to mitigate power concentration can face significant headwinds from incumbent powers." :contentReference[oaicite:34]{index=34}
+    - "The key missing ingredient is political and social will to take control of the AI development process."
+    - "We can start immediately with enhanced oversight and liability, while building toward more comprehensive governance."
+    - "Decent human institutions, empowered by AI tools, can do it."
+    - "By undermining human discourse, debate, and election systems, they could reduce the credibility of democratic institutions… ending democracy in states where it currently exists."
+    - "Our current governance structures are struggling: they are slow to respond, often captured by special interests, and increasingly distrusted by the public."
+    - "Approaches to mitigate power concentration can face significant headwinds from incumbent powers."
 
 ScientificCommunity:
   initial_states:
@@ -97,8 +97,8 @@ ScientificCommunity:
     - severity: Moderate
       explanation: Global coordination exists but fragmented and underpowered
   referenced_quotes:
-    - "Over the past half-decade… AI has transformed from a relatively pure research field into much more of an engineering and product field, largely driven by some of the world’s largest companies… Researchers… are no longer in charge of the process." :contentReference[oaicite:35]{index=35}
-    - "Agreements to bring such measures to the international level, including international bodies to harmonize norms and standards, and potentially international agencies to review safety cases." :contentReference[oaicite:36]{index=36}
-    - "Company consortia, working with NGOs and government agencies, should develop standards and norms defining these terms… and how courts should interpret liability where safe harbors are not proactively claimed." :contentReference[oaicite:37]{index=37}
-    - "A national investment project in scientific advancement using AI… running as a partnership between the DOE, NSF, and NIH." :contentReference[oaicite:38]{index=38}
-    - "In parallel, a set of international standards may be developed so that training and running of AIs above a threshold of computation… are required to adhere to those standards." :contentReference[oaicite:39]{index=39}
+    - "Over the past half-decade… AI has transformed from a relatively pure research field into much more of an engineering and product field, largely driven by some of the world’s largest companies… Researchers… are no longer in charge of the process."
+    - "Agreements to bring such measures to the international level, including international bodies to harmonize norms and standards, and potentially international agencies to review safety cases."
+    - "Company consortia, working with NGOs and government agencies, should develop standards and norms defining these terms… and how courts should interpret liability where safe harbors are not proactively claimed."
+    - "A national investment project in scientific advancement using AI… running as a partnership between the DOE, NSF, and NIH."
+    - "In parallel, a set of international standards may be developed so that training and running of AIs above a threshold of computation… are required to adhere to those standards."

--- a/scenarios/03-keep-the-future-human.yaml
+++ b/scenarios/03-keep-the-future-human.yaml
@@ -11,13 +11,13 @@ Governments:
     - severity: Critical
       explanation: No international treaties or institutions; rivalry (e.g., US–China) intensifies
   referenced_quotes:
-    - "The US, China, and any other countries hosting advanced chip manufacturing capability negotiate an international agreement." :contentReference[oaicite:0]{index=0}
-    - "This agreement creates a new international agency, analogous to the International Atomic Energy Agency, charged with overseeing AI training and execution." :contentReference[oaicite:1]{index=1}
-    - "The agency... agrees on computation limitations which then take legal force in the signatory countries." :contentReference[oaicite:2]{index=2}
-    - "In parallel, a set of international standards may be developed so that training and running of AIs above a threshold of computation... are required to adhere to those standards." :contentReference[oaicite:3]{index=3}
-    - "At least China and the US must independently decide... not to build superintelligence. Then an international agreement between them and others, with a strong verification and enforcement mechanism, is needed..." :contentReference[oaicite:4]{index=4}
-    - "Races for AI supremacy... drive us toward uncontrolled powerful AI systems... An AGI race between the US and China is a race to determine which nation superintelligence gets first." :contentReference[oaicite:5]{index=5}
-    - "It would take a combination of intervention from the outside (i.e. governments) to stop corporations, and agreements between governments to stop themselves." :contentReference[oaicite:6]{index=6}
+    - "The US, China, and any other countries hosting advanced chip manufacturing capability negotiate an international agreement."
+    - "This agreement creates a new international agency, analogous to the International Atomic Energy Agency, charged with overseeing AI training and execution."
+    - "The agency... agrees on computation limitations which then take legal force in the signatory countries."
+    - "In parallel, a set of international standards may be developed so that training and running of AIs above a threshold of computation... are required to adhere to those standards."
+    - "At least China and the US must independently decide... not to build superintelligence. Then an international agreement between them and others, with a strong verification and enforcement mechanism, is needed..."
+    - "Races for AI supremacy... drive us toward uncontrolled powerful AI systems... An AGI race between the US and China is a race to determine which nation superintelligence gets first."
+    - "It would take a combination of intervention from the outside (i.e. governments) to stop corporations, and agreements between governments to stop themselves."
 
 Corporations:
   initial_states:
@@ -28,11 +28,11 @@ Corporations:
     - severity: Large
       explanation: Some cultural dissent, but weak relative to leadership and profit incentives
   referenced_quotes:
-    - "It is that AGI can directly, one-for-one, replace workers. Not augment, not empower, not make more productive." :contentReference[oaicite:7]{index=7}
-    - "AI companies are also cognizant of who is willing to pay... a company will pay thousands of dollars per year to replace your labor, if they can." :contentReference[oaicite:8]{index=8}
-    - "The key missing ingredient is political and social will to take control of the AI development process." :contentReference[oaicite:9]{index=9}
-    - "Longer-term containment... would require international agreements... But we can start immediately with enhanced oversight and liability, while building toward more comprehensive governance." :contentReference[oaicite:10]{index=10}
-    - "This approach... is practical: while international coordination will be needed, verification and enforcement can work through the small number of companies controlling the specialized hardware supply chain." :contentReference[oaicite:11]{index=11}
+    - "It is that AGI can directly, one-for-one, replace workers. Not augment, not empower, not make more productive."
+    - "AI companies are also cognizant of who is willing to pay... a company will pay thousands of dollars per year to replace your labor, if they can."
+    - "The key missing ingredient is political and social will to take control of the AI development process."
+    - "Longer-term containment... would require international agreements... But we can start immediately with enhanced oversight and liability, while building toward more comprehensive governance."
+    - "This approach... is practical: while international coordination will be needed, verification and enforcement can work through the small number of companies controlling the specialized hardware supply chain."
 
 HardwareManufacturers:
   initial_states:
@@ -43,11 +43,11 @@ HardwareManufacturers:
     - severity: Large
       explanation: Global standards absent due to geopolitical rivalry
   referenced_quotes:
-    - "Because specialized AI hardware is made by only a handful of companies, verification and enforcement are feasible through the existing supply chain." :contentReference[oaicite:12]{index=12}
-    - "Similar hardware features embedded in cutting edge AI-relevant computing hardware could play an extremely useful role in AI security and governance." :contentReference[oaicite:13]{index=13}
-    - "Geolocation... Allow-listed connections... Metered inference or training (and auto-offswitch)..." :contentReference[oaicite:14]{index=14}
-    - "Implementation and enforcement rely on standard legal restrictions... backed up by terms-of-use of the hardware and by hardware controls, vastly simplifying enforcement and forestalling cheating." :contentReference[oaicite:15]{index=15}
-    - "Additional countries are strongly encouraged to join the existing international agreement: export controls by signatory countries restrict access to high-end hardware by non-signatories..." :contentReference[oaicite:16]{index=16}
+    - "Because specialized AI hardware is made by only a handful of companies, verification and enforcement are feasible through the existing supply chain."
+    - "Similar hardware features embedded in cutting edge AI-relevant computing hardware could play an extremely useful role in AI security and governance."
+    - "Geolocation... Allow-listed connections... Metered inference or training (and auto-offswitch)..."
+    - "Implementation and enforcement rely on standard legal restrictions... backed up by terms-of-use of the hardware and by hardware controls, vastly simplifying enforcement and forestalling cheating."
+    - "Additional countries are strongly encouraged to join the existing international agreement: export controls by signatory countries restrict access to high-end hardware by non-signatories..."
 
 Regulators:
   initial_states:
@@ -58,10 +58,10 @@ Regulators:
     - severity: Critical
       explanation: No international enforcement mechanisms; rival governments do not cooperate
   referenced_quotes:
-    - "This agreement creates a new international agency, analogous to the International Atomic Energy Agency, charged with overseeing AI training and execution." :contentReference[oaicite:17]{index=17}
-    - "Agreements to bring such measures to the international level, including international bodies to harmonize norms and standards, and potentially international agencies to review safety cases." :contentReference[oaicite:18]{index=18}
-    - "It is likely that at least some measures addressing large-scale safety risks will require agreement at the international level, with individual jurisdictions enforcing rules based on international agreements." :contentReference[oaicite:19]{index=19}
-    - "A standards organization... should codify a detailed technical standard for the total compute used in training and operating AI models, in FLOP, and the speed in FLOP/s at which they operate." :contentReference[oaicite:20]{index=20}
+    - "This agreement creates a new international agency, analogous to the International Atomic Energy Agency, charged with overseeing AI training and execution."
+    - "Agreements to bring such measures to the international level, including international bodies to harmonize norms and standards, and potentially international agencies to review safety cases."
+    - "It is likely that at least some measures addressing large-scale safety risks will require agreement at the international level, with individual jurisdictions enforcing rules based on international agreements."
+    - "A standards organization... should codify a detailed technical standard for the total compute used in training and operating AI models, in FLOP, and the speed in FLOP/s at which they operate."
 
 CivilSociety:
   initial_states:
@@ -72,12 +72,12 @@ CivilSociety:
     - severity: Moderate
       explanation: Public instincts align but education and awareness are lacking
   referenced_quotes:
-    - "We can engineer Tool AI to empower humanity... Tool AI systems can be extremely capable while avoiding the dangerous triple-intersection... When properly governed, it can make human experts and institutions more effective rather than replacing them." :contentReference[oaicite:21]{index=21}
-    - "Decent human institutions, empowered by AI tools, can do it." :contentReference[oaicite:22]{index=22}
-    - "The key missing ingredient is political and social will to take control of the AI development process." :contentReference[oaicite:23]{index=23}
-    - "By imposing some hard, global limits, we can keep AI’s general capability to approximately human level... Imposing limits would require international cooperation..." :contentReference[oaicite:24]{index=24}
-    - "Our society’s failure to control these dynamics so far does not bode well." :contentReference[oaicite:25]{index=25}
-    - "AI could facilitate genuine dialogue... helping each side better understand the other’s actual concerns and values... Current AI is totally capable of doing this work, but the tools... will not come into being by themselves, or via market incentives." :contentReference[oaicite:26]{index=26}
+    - "We can engineer Tool AI to empower humanity... Tool AI systems can be extremely capable while avoiding the dangerous triple-intersection... When properly governed, it can make human experts and institutions more effective rather than replacing them."
+    - "Decent human institutions, empowered by AI tools, can do it."
+    - "The key missing ingredient is political and social will to take control of the AI development process."
+    - "By imposing some hard, global limits, we can keep AI’s general capability to approximately human level... Imposing limits would require international cooperation..."
+    - "Our society’s failure to control these dynamics so far does not bode well."
+    - "AI could facilitate genuine dialogue... helping each side better understand the other’s actual concerns and values... Current AI is totally capable of doing this work, but the tools... will not come into being by themselves, or via market incentives."
 
 ScientificCommunity:
   initial_states:
@@ -88,8 +88,8 @@ ScientificCommunity:
     - severity: Small
       explanation: Advocacy growing and aligned, but not yet mainstreamed
   referenced_quotes:
-    - "This is not inevitable; humanity can, very concretely, decide not to build our replacement." :contentReference[oaicite:27]{index=27}
-    - "We may eventually choose to develop yet more powerful and more sovereign systems... only after we have developed the scientific understanding and governance capacity to do so safely." :contentReference[oaicite:28]{index=28}
-    - "A national investment project in scientific advancement using AI... running as a partnership between the DOE, NSF, and NIH." :contentReference[oaicite:29]{index=29}
-    - "Agreements to bring such measures to the international level, including international bodies to harmonize norms and standards..." :contentReference[oaicite:30]{index=30}
-    - "Prediction is very difficult, but there are some dynamics that are well enough understood... despite AI’s promise, they give good reason to be profoundly pessimistic about how our current trajectory will play out." :contentReference[oaicite:31]{index=31}
+    - "This is not inevitable; humanity can, very concretely, decide not to build our replacement."
+    - "We may eventually choose to develop yet more powerful and more sovereign systems... only after we have developed the scientific understanding and governance capacity to do so safely."
+    - "A national investment project in scientific advancement using AI... running as a partnership between the DOE, NSF, and NIH."
+    - "Agreements to bring such measures to the international level, including international bodies to harmonize norms and standards..."
+    - "Prediction is very difficult, but there are some dynamics that are well enough understood... despite AI’s promise, they give good reason to be profoundly pessimistic about how our current trajectory will play out."


### PR DESCRIPTION
## Summary
- remove :contentReference annotations from all scenario YAML referenced quotes so text is plain strings

## Testing
- pytest -k 'not genai_example'
- pytest (fails: KeyboardInterrupt while waiting for external Google API client)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e7c29dae4833388b18b1ab1569f4b)