### PR TITLE
Improve action outcome handling and reroll safeguards

### DIFF
--- a/cli_game.py
+++ b/cli_game.py
@@ -203,6 +203,18 @@ def main() -> None:
                 )
                 print(failure_text)
                 cost = state.next_reroll_cost(char, option)
+                can_reroll, shortages = state.reroll_affordability(char, option)
+                if not can_reroll:
+                    details = "; ".join(
+                        f"{target}: have {available}, need {needed}"
+                        for target, available, needed in shortages
+                    )
+                    print(
+                        "Cannot reroll due to insufficient credibility"
+                        + (f" ({details})" if details else "")
+                    )
+                    state.finalize_failed_action(char, option)
+                    break
                 if cost > 0:
                     prompt = f"Reroll at a credibility cost of {cost}? (y/n): "
                 else:

--- a/rpg/constants.py
+++ b/rpg/constants.py
@@ -1,0 +1,7 @@
+"""Common constants used throughout the RPG package."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+ACTION_ATTRIBUTES = ("leadership", "technology", "policy", "network")
+
+__all__ = ["ACTION_ATTRIBUTES"]

--- a/rpg/game_state.py
+++ b/rpg/game_state.py
@@ -6,17 +6,35 @@ from __future__ import annotations
 
 import logging
 import random
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from html import escape
 from typing import Dict, Iterable, List, Sequence, Tuple
 
 from .character import Character, PlayerCharacter, ResponseOption
+from .constants import ACTION_ATTRIBUTES
 from .credibility import CREDIBILITY_PENALTY, CREDIBILITY_REWARD, CredibilityMatrix
 from .config import GameConfig, load_game_config
 from .conversation import ConversationEntry
 
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_action_option(action: ResponseOption | str) -> ResponseOption:
+    """Return ``action`` as an action-type :class:`ResponseOption` with an attribute."""
+
+    created = not isinstance(action, ResponseOption)
+    option = (
+        action
+        if isinstance(action, ResponseOption)
+        else ResponseOption(text=str(action), type="action")
+    )
+    if created and option.is_action and not option.related_attribute:
+        option = replace(
+            option,
+            related_attribute=random.choice(ACTION_ATTRIBUTES),
+        )
+    return option
 
 
 DEFAULT_PLAYER_FACTION = "CivilSociety"
@@ -378,11 +396,7 @@ class GameState:
     ) -> bool:
         """Resolve an action and automatically log failures when not rerolled."""
 
-        option = (
-            action
-            if isinstance(action, ResponseOption)
-            else ResponseOption(text=str(action), type="action")
-        )
+        option = _coerce_action_option(action)
         attempt = self.attempt_action(character, option, targets=targets)
         if attempt.success:
             return True
@@ -399,11 +413,7 @@ class GameState:
     ) -> ActionAttempt:
         """Attempt an action without immediately logging failure results."""
 
-        option = (
-            action
-            if isinstance(action, ResponseOption)
-            else ResponseOption(text=str(action), type="action")
-        )
+        option = _coerce_action_option(action)
         if not option.is_action:
             raise ValueError("attempt_action requires an action-type ResponseOption")
         logger.info("Evaluating action '%s' for %s", option.text, character.name)
@@ -532,11 +542,7 @@ class GameState:
         character: Character,
         action: ResponseOption | str,
     ) -> None:
-        option = (
-            action
-            if isinstance(action, ResponseOption)
-            else ResponseOption(text=str(action), type="action")
-        )
+        option = _coerce_action_option(action)
         key = (character.name, option.text)
         attempt = self.pending_failures.pop(key, None)
         reroll_count = self.reroll_counts.pop(key, None) or 0
@@ -564,11 +570,7 @@ class GameState:
         *,
         targets: Iterable[str] | None = None,
     ) -> ActionAttempt:
-        option = (
-            action
-            if isinstance(action, ResponseOption)
-            else ResponseOption(text=str(action), type="action")
-        )
+        option = _coerce_action_option(action)
         key = (character.name, option.text)
         attempt = self.pending_failures.pop(key, None)
         if attempt is None:
@@ -591,17 +593,42 @@ class GameState:
         character: Character,
         action: ResponseOption | str,
     ) -> int:
-        option = (
-            action
-            if isinstance(action, ResponseOption)
-            else ResponseOption(text=str(action), type="action")
-        )
+        option = _coerce_action_option(action)
         key = (character.name, option.text)
         attempt = self.pending_failures.get(key)
         if not attempt:
             return 0
         reroll_count = self.reroll_counts.get(key, 0) + 1
         return attempt.credibility_cost * reroll_count
+
+    def reroll_affordability(
+        self,
+        character: Character,
+        action: ResponseOption | str,
+    ) -> Tuple[bool, List[Tuple[str, int, int]]]:
+        """Return whether a reroll is affordable and any shortages."""
+
+        option = _coerce_action_option(action)
+        key = (character.name, option.text)
+        attempt = self.pending_failures.get(key)
+        if not attempt:
+            return True, []
+        reroll_count = self.reroll_counts.get(key, 0) + 1
+        cost = attempt.credibility_cost * reroll_count
+        if cost <= 0:
+            return True, []
+        actor_faction = getattr(character, "faction", None)
+        targets = list(attempt.targets or [actor_faction])
+        shortages: List[Tuple[str, int, int]] = []
+        self.credibility.ensure_faction(self.player_faction)
+        for target in targets:
+            if not target:
+                continue
+            self.credibility.ensure_faction(target)
+            available = self.credibility.value(self.player_faction, target)
+            if available - cost < 0:
+                shortages.append((target, available, cost))
+        return not shortages, shortages
 
     def _apply_credibility_updates(
         self,


### PR DESCRIPTION
## Summary
- introduce a shared action attribute constant and ensure forced actions receive a random attribute when necessary
- add helpers that assign attributes when coercing string actions and block unaffordable rerolls in both the game state and CLI
- update the web flow to show detailed success outcomes, surface reroll affordability warnings, and provide buttons to continue or return
- add tests covering coerced action attributes and reroll affordability checks

## Testing
- pytest tests/test_credibility.py tests/test_game_state.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911163c13848333a1cd13322be5b4b7)