### PR TITLE
Refactor web service templates and assets

### DIFF
--- a/web/snippets/global_footer.html
+++ b/web/snippets/global_footer.html
@@ -1,0 +1,7 @@
+<footer class="global-footer">
+  <p class="footer-note">Need a refresher or want to inspect the code?</p>
+  <div class="footer-links">
+    <a href="/instructions">Instructions</a>
+    <a href="{github_url}" target="_blank" rel="noopener">GitHub</a>
+  </div>
+</footer>

--- a/web/snippets/roll_indicator.html
+++ b/web/snippets/roll_indicator.html
@@ -1,0 +1,4 @@
+<div class="roll-indicator" id="roll-indicator" aria-hidden="true">
+  <img src="{roll_asset_path}" alt="Random sampling animation">
+  <p>Sampling outcomes...</p>
+</div>

--- a/web/snippets/roll_indicator.js
+++ b/web/snippets/roll_indicator.js
@@ -1,0 +1,42 @@
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const indicator = document.getElementById('roll-indicator');
+  if (!indicator) {
+    return;
+  }
+  let hideTimer = null;
+  let finalizeTimer = null;
+  const scheduleHide = function () {
+    indicator.classList.add('fade-out');
+    hideTimer = null;
+    finalizeTimer = window.setTimeout(function () {
+      indicator.classList.remove('visible');
+      indicator.classList.remove('fade-out');
+      indicator.setAttribute('aria-hidden', 'true');
+    }, 350);
+  };
+  const showIndicator = function () {
+    indicator.classList.remove('fade-out');
+    indicator.classList.add('visible');
+    indicator.setAttribute('aria-hidden', 'false');
+    if (hideTimer) {
+      window.clearTimeout(hideTimer);
+    }
+    if (finalizeTimer) {
+      window.clearTimeout(finalizeTimer);
+    }
+    hideTimer = window.setTimeout(scheduleHide, 3200);
+  };
+  document.querySelectorAll('form.roll-trigger').forEach(function (form) {
+    form.addEventListener('submit', showIndicator);
+  });
+  document.querySelectorAll('form.options-form').forEach(function (form) {
+    form.addEventListener('submit', function () {
+      const selected = form.querySelector("input[name='response']:checked");
+      if (selected && selected.dataset && selected.dataset.kind === 'action') {
+        showIndicator();
+      }
+    });
+  });
+});
+</script>

--- a/web/snippets/state_refresh.js
+++ b/web/snippets/state_refresh.js
@@ -1,0 +1,72 @@
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const container = document.querySelector('.state-container');
+  if (!container) {
+    return;
+  }
+  const timeTarget = document.getElementById('time-status');
+  const findRoot = function () {
+    return container.querySelector('#state');
+  };
+  let root = findRoot();
+  const readVersion = function () {
+    return root ? parseInt(root.getAttribute('data-state-version') || '0', 10) : 0;
+  };
+  const readPending = function () {
+    return !!(root && root.getAttribute('data-assessment-pending') === 'true');
+  };
+  let version = readVersion();
+  let pending = readPending();
+  let timer = null;
+  const applyHtml = function (html) {
+    container.innerHTML = html;
+    root = findRoot();
+    version = readVersion();
+    pending = readPending();
+  };
+  const schedule = function (delay) {
+    if (timer) {
+      window.clearTimeout(timer);
+    }
+    timer = window.setTimeout(poll, delay);
+  };
+  const poll = function () {
+    fetch('/state', { headers: { Accept: 'application/json' } })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Bad response');
+        }
+        return response.json();
+      })
+      .then(function (data) {
+        if (typeof data.state_html === 'string') {
+          const changedVersion =
+            typeof data.progress_version === 'number' && data.progress_version !== version;
+          const changedPending =
+            typeof data.assessment_pending === 'boolean' && data.assessment_pending !== pending;
+          if (changedVersion || changedPending || !root) {
+            applyHtml(data.state_html);
+          }
+        }
+        if (typeof data.progress_version === 'number') {
+          version = data.progress_version;
+        }
+        if (typeof data.assessment_pending === 'boolean') {
+          pending = data.assessment_pending;
+          if (root) {
+            root.setAttribute('data-assessment-pending', pending ? 'true' : 'false');
+          }
+        }
+        if (timeTarget && typeof data.time_status === 'string') {
+          timeTarget.textContent = data.time_status;
+        }
+        schedule(pending ? 1200 : 4500);
+      })
+      .catch(function (error) {
+        console.error('State polling failed', error);
+        schedule(6000);
+      });
+  };
+  schedule(pending ? 1200 : 4500);
+});
+</script>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,1062 @@
+body{
+  font-family:'Inter',sans-serif;
+  margin:0;
+  background:#f8fafc;
+  color:#0f172a;
+}
+body.page-landing{
+  background:#f3f4f8;
+  color:#1f2933;
+}
+body.page-profile{
+  background:#f3f4f8;
+}
+.global-footer{
+  max-width:960px;
+  margin:3rem auto 2rem;
+  padding-top:1.5rem;
+  border-top:1px solid #e2e8f0;
+  text-align:center;
+  color:#475569;
+}
+.global-footer .footer-links{
+  display:flex;
+  justify-content:center;
+  gap:1.5rem;
+  margin-top:0.75rem;
+  flex-wrap:wrap;
+}
+.global-footer a{
+  color:#1d4ed8;
+  font-weight:600;
+  text-decoration:none;
+}
+.global-footer a:hover{
+  text-decoration:underline;
+}
+.footer-note{
+  margin:0;
+}
+.tooltip-icon{
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+}
+.tooltip-icon img{
+  width:16px;
+  height:16px;
+  border-radius:50%;
+  box-shadow:0 0 0 1px rgba(15,23,42,0.35);
+  cursor:pointer;
+  background:#ffffff;
+}
+.tooltip-text{
+  position:absolute;
+  bottom:125%;
+  left:50%;
+  transform:translateX(-50%);
+  background:#1f2933;
+  color:#ffffff;
+  padding:0.45rem 0.6rem;
+  border-radius:6px;
+  font-size:0.8rem;
+  line-height:1.2;
+  white-space:normal;
+  width:220px;
+  box-shadow:0 12px 28px rgba(15,23,42,0.25);
+  opacity:0;
+  visibility:hidden;
+  transition:opacity 0.2s ease-in-out,visibility 0.2s ease-in-out;
+  z-index:10;
+  text-align:left;
+}
+.tooltip-icon:hover .tooltip-text{
+  opacity:1;
+  visibility:visible;
+}
+.tooltip-icon::after{
+  content:"";
+  position:absolute;
+  bottom:110%;
+  left:50%;
+  transform:translateX(-50%);
+  border-width:6px;
+  border-style:solid;
+  border-color:transparent transparent #1f2933 transparent;
+  opacity:0;
+  transition:opacity 0.2s ease-in-out;
+}
+.tooltip-icon:hover::after{
+  opacity:1;
+}
+.layout-container{
+  max-width:1200px;
+  margin:2rem auto;
+  display:grid;
+  grid-template-columns:260px minmax(0,1fr) 260px;
+  gap:1.5rem;
+  align-items:flex-start;
+  padding:0 1.5rem;
+  box-sizing:border-box;
+}
+.panel{
+  padding:0;
+  box-sizing:border-box;
+}
+.player-panel,.partner-panel{
+  position:sticky;
+  top:1.5rem;
+}
+.profile-card{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:0.75rem;
+  padding:1.25rem;
+  border-radius:16px;
+  background:#ffffff;
+  border:1px solid #e2e8f0;
+  box-shadow:0 12px 28px rgba(15,23,42,0.08);
+}
+.profile-photo{
+  width:120px;
+  height:120px;
+  border-radius:14px;
+  overflow:hidden;
+  background:linear-gradient(135deg,#e0e7ff,#c7d2fe);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  color:#1e3a8a;
+  font-weight:600;
+  font-size:1rem;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+}
+.profile-photo img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+}
+.profile-name{
+  margin:0;
+  font-size:1.15rem;
+  text-align:center;
+}
+.attribute-list{
+  list-style:none;
+  padding:0;
+  margin:0;
+  width:100%;
+  display:flex;
+  flex-direction:column;
+  gap:0.6rem;
+}
+.attribute-list li{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:0.65rem 0.75rem;
+  border-radius:12px;
+  background:#f8fafc;
+  box-shadow:0 8px 18px rgba(15,23,42,0.05);
+}
+.attribute-label{
+  display:flex;
+  align-items:center;
+  gap:0.35rem;
+  font-weight:600;
+  color:#1d4ed8;
+}
+.attribute-value{
+  font-weight:600;
+  color:#0f172a;
+}
+.credibility-box{
+  width:100%;
+  padding:0.85rem;
+  border:1px solid #cbd5f5;
+  border-radius:12px;
+  background:#eef2ff;
+  text-align:center;
+  font-size:0.95rem;
+  color:#1e3a8a;
+  font-weight:600;
+  margin-top:0.75rem;
+}
+.credibility-box .attribute-label{
+  justify-content:center;
+  color:#1e3a8a;
+}
+.credibility-box strong{
+  display:block;
+  font-size:1.25rem;
+  margin-top:0.35rem;
+  color:#0f172a;
+}
+.profile-footer{
+  margin-top:0.75rem;
+}
+.profile-footer a{
+  color:#1d4ed8;
+  font-weight:600;
+  text-decoration:none;
+}
+.profile-footer a:hover{
+  text-decoration:underline;
+}
+.reroll-actions,.action-outcome-actions,.conversation-actions{
+  display:flex;
+  gap:0.75rem;
+  flex-wrap:wrap;
+  margin-top:0.5rem;
+}
+.reroll-actions form,.action-outcome-actions form,.mode-actions form{
+  margin:0;
+}
+.warning-text{
+  color:#9c2f2f;
+  font-weight:600;
+}
+.roll-indicator{
+  display:none;
+  align-items:center;
+  justify-content:center;
+  gap:0.75rem;
+  margin:1.25rem auto 0 auto;
+  padding:0.85rem 1.4rem;
+  border-radius:999px;
+  background:#eef2ff;
+  box-shadow:0 10px 24px rgba(59,130,246,0.18);
+  color:#1d4ed8;
+  font-weight:600;
+  max-width:360px;
+  opacity:0;
+  transition:opacity 0.3s ease;
+}
+.roll-indicator.visible{
+  display:flex;
+  opacity:1;
+}
+.roll-indicator.fade-out{
+  opacity:0;
+}
+.roll-indicator img{
+  width:64px;
+  height:64px;
+  object-fit:contain;
+  margin:0;
+}
+.roll-indicator p{
+  margin:0;
+  font-size:1rem;
+  color:#1d4ed8;
+}
+@media (max-width:1100px){
+  .layout-container{
+    grid-template-columns:repeat(1,minmax(0,1fr));
+  }
+  .player-panel,.partner-panel{
+    position:static;
+  }
+}
+.conversation-page{
+  padding-bottom:2rem;
+}
+.conversation-panel{
+  width:100%;
+}
+.conversation-content{
+  display:flex;
+  flex-direction:column;
+  gap:1.5rem;
+}
+.conversation-content section{
+  background:#ffffff;
+  border-radius:16px;
+  padding:1.5rem;
+  box-shadow:0 12px 28px rgba(15,23,42,0.08);
+}
+.conversation-content h2{
+  margin-top:0;
+  font-size:1.35rem;
+}
+.conversation-log{
+  list-style:none;
+  padding:0;
+  margin:0;
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+}
+.conversation-log li{
+  background:#f8fafc;
+  border-radius:14px;
+  padding:1rem 1.15rem;
+  box-shadow:0 10px 24px rgba(15,23,42,0.06);
+}
+.message-header{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  margin-bottom:0.35rem;
+}
+.message-header .speaker{
+  font-weight:600;
+  color:#1d4ed8;
+}
+.message-header .message-type{
+  font-size:0.85rem;
+  font-weight:600;
+  color:#475569;
+  background:#e2e8f0;
+  border-radius:999px;
+  padding:0.25rem 0.6rem;
+  text-transform:uppercase;
+  letter-spacing:0.05em;
+}
+.conversation-log p{
+  margin:0;
+  color:#1f2933;
+  line-height:1.55;
+}
+.empty-conversation{
+  margin:0;
+  color:#475569;
+  font-style:italic;
+}
+.options-form{
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+}
+.options-form ul{
+  list-style:none;
+  padding:0;
+  margin:0;
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+}
+.response-option{
+  display:flex;
+  gap:0.9rem;
+  align-items:flex-start;
+  background:#f8fafc;
+  border-radius:14px;
+  padding:1rem 1.15rem;
+  box-shadow:0 12px 28px rgba(15,23,42,0.08);
+}
+.response-option input[type='radio']{
+  width:20px;
+  height:20px;
+  margin-top:0.25rem;
+}
+.response-option label{
+  cursor:pointer;
+  display:flex;
+  flex-direction:column;
+  gap:0.3rem;
+  font-weight:500;
+  color:#0f172a;
+}
+.option-title{
+  font-size:1rem;
+  font-weight:600;
+  color:#111827;
+}
+.option-description{
+  font-size:0.9rem;
+  color:#475569;
+}
+.options-actions,.mode-actions,.campaign-actions{
+  display:flex;
+  gap:0.75rem;
+  flex-wrap:wrap;
+}
+.primary-button,.mode-actions a,.mode-actions button,.campaign-actions a,.campaign-actions button,.instructions-actions a,.character-select-actions button,.profile-actions a,.faction-actions a{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:0.75rem 1.75rem;
+  border-radius:999px;
+  background:#1d4ed8;
+  color:#ffffff;
+  font-weight:600;
+  text-decoration:none;
+  border:none;
+  cursor:pointer;
+  box-shadow:0 12px 28px rgba(29,78,216,0.18);
+}
+.primary-button:hover,.profile-actions a:hover,.instructions-actions a:hover,.campaign-actions a:hover{
+  background:#1e40af;
+}
+.primary-button.secondary,.mode-actions a.secondary,.mode-actions button.secondary,.campaign-actions a.secondary,.campaign-actions button.secondary,.instructions-actions a.secondary,.character-select-actions button.secondary,.profile-actions a.secondary,.faction-actions a.secondary{
+  background:#334155;
+}
+.primary-button.secondary:hover,.mode-actions a.secondary:hover,.mode-actions button.secondary:hover,.campaign-actions a.secondary:hover,.campaign-actions button.secondary:hover,.instructions-actions a.secondary:hover,.character-select-actions button.secondary:hover,.profile-actions a.secondary:hover,.faction-actions a.secondary:hover{
+  background:#1f2937;
+}
+.conversation-actions a{
+  min-width:200px;
+  text-align:center;
+}
+.inline-loading{
+  display:flex;
+  align-items:center;
+  gap:0.5rem;
+  font-weight:500;
+  color:#1e293b;
+}
+.inline-loading img{
+  width:32px;
+  height:32px;
+  object-fit:contain;
+}
+.loading-page{
+  min-height:60vh;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  padding:2rem;
+  gap:1rem;
+}
+.state-container{
+  margin:2rem auto 0 auto;
+  max-width:960px;
+  padding:0 1.5rem;
+  box-sizing:border-box;
+}
+.faction-detail-page{
+  max-width:960px;
+  margin:2rem auto;
+  padding:0 1.5rem 3rem 1.5rem;
+}
+.faction-detail-page.single .faction-detail{
+  box-shadow:0 12px 28px rgba(15,23,42,0.08);
+}
+.faction-detail{
+  background:#ffffff;
+  border-radius:16px;
+  padding:1.75rem;
+  box-shadow:0 10px 24px rgba(15,23,42,0.08);
+  margin-bottom:1.5rem;
+}
+.faction-detail h1,.faction-detail h2{
+  margin-top:0;
+}
+.faction-section ul{
+  margin:0.75rem 0 0 1.25rem;
+  line-height:1.6;
+}
+.gap-list{
+  list-style:none;
+  padding:0;
+  margin:0.75rem 0 0 0;
+  display:flex;
+  flex-direction:column;
+  gap:0.75rem;
+}
+.gap-list li{
+  background:#f8fafc;
+  border-radius:12px;
+  padding:0.85rem 1rem;
+  box-shadow:0 10px 24px rgba(15,23,42,0.06);
+}
+.gap-severity{
+  display:inline-block;
+  margin-right:0.5rem;
+  font-weight:700;
+  color:#b45309;
+  text-transform:uppercase;
+  letter-spacing:0.05em;
+  font-size:0.85rem;
+}
+.quote-list{
+  margin:0.75rem 0 0 1.25rem;
+  line-height:1.6;
+}
+.faction-actions{
+  display:flex;
+  gap:1rem;
+  flex-wrap:wrap;
+  margin-top:2rem;
+}
+.faction-note{
+  margin:1rem 0 0 0;
+  color:#475569;
+  line-height:1.6;
+}
+.faction-grid{
+  display:grid;
+  gap:1.5rem;
+  grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+}
+.faction-detail-page.single .faction-note{
+  margin-top:1.25rem;
+}
+.instructions-page{
+  max-width:960px;
+  margin:2rem auto;
+  padding:2.25rem 1.75rem;
+  background:#ffffff;
+  border-radius:18px;
+  box-shadow:0 12px 28px rgba(15,23,42,0.08);
+}
+.instructions-page h1{
+  margin-top:0;
+  font-size:2.2rem;
+}
+.instructions-page ol{
+  margin:1.25rem 0 1.5rem 1.25rem;
+  line-height:1.7;
+}
+.instructions-page li{
+  margin-bottom:0.85rem;
+}
+.resource-callout{
+  margin:1.75rem 0;
+  padding:1.25rem;
+  border-radius:14px;
+  background:#eef2ff;
+  box-shadow:0 10px 24px rgba(59,130,246,0.12);
+}
+.resource-callout h2{
+  margin:0 0 0.75rem 0;
+  font-size:1.3rem;
+  color:#1d4ed8;
+}
+.instructions-page a{
+  color:#1d4ed8;
+  font-weight:600;
+  text-decoration:none;
+}
+.instructions-page a:hover{
+  text-decoration:underline;
+}
+.instructions-page p{
+  line-height:1.6;
+}
+.instructions-actions{
+  margin-top:2rem;
+  display:flex;
+  gap:1rem;
+  flex-wrap:wrap;
+}
+.persona-card{
+  background:#ffffff;
+  border-radius:16px;
+  padding:1.5rem;
+  box-shadow:0 12px 28px rgba(15,23,42,0.1);
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+}
+.persona-header{
+  display:flex;
+  align-items:flex-start;
+  gap:1rem;
+}
+.persona-photo{
+  width:96px;
+  height:96px;
+  border-radius:14px;
+  overflow:hidden;
+  background:linear-gradient(135deg,#e0f2fe,#bfdbfe);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:700;
+  color:#1e3a8a;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+}
+.persona-photo img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+}
+.persona-header h3{
+  margin:0;
+  font-size:1.3rem;
+  color:#0f172a;
+}
+.persona-faction{
+  margin:0.25rem 0 0 0;
+  font-weight:600;
+  color:#1e3a8a;
+}
+.persona-guidance{
+  margin:0.5rem 0 0 0;
+  font-size:0.95rem;
+  color:#1f2933;
+  line-height:1.5;
+}
+.persona-attributes{
+  list-style:none;
+  padding:0;
+  margin:0;
+  display:grid;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  gap:0.6rem;
+}
+.persona-attributes li{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:0.6rem 0.75rem;
+  border-radius:12px;
+  background:#f8fafc;
+  box-shadow:0 10px 24px rgba(15,23,42,0.06);
+}
+.persona-attributes .attribute-label{
+  font-weight:600;
+  color:#1d4ed8;
+}
+.persona-attributes .attribute-value{
+  font-weight:600;
+  color:#0f172a;
+}
+.persona-body p{
+  margin:0.35rem 0;
+  line-height:1.55;
+  font-size:0.95rem;
+  color:#1f2933;
+}
+.persona-body strong{
+  color:#0f172a;
+}
+.profile-page{
+  max-width:880px;
+  margin:2rem auto;
+  padding:0 1.5rem;
+}
+.profile-page h1{
+  font-size:2.1rem;
+  margin-bottom:1.25rem;
+  text-align:center;
+}
+.profile-actions{
+  margin-top:1.75rem;
+  text-align:center;
+  display:flex;
+  gap:1rem;
+  flex-wrap:wrap;
+  justify-content:center;
+}
+.profile-actions a{
+  gap:0.5rem;
+}
+.credibility-matrix{
+  margin-top:2rem;
+  background:#ffffff;
+  border-radius:16px;
+  padding:1.5rem;
+  box-shadow:0 12px 28px rgba(15,23,42,0.08);
+}
+.credibility-matrix table{
+  width:100%;
+  border-collapse:collapse;
+}
+.credibility-matrix th,.credibility-matrix td{
+  padding:0.75rem;
+  border-bottom:1px solid #e2e8f0;
+  text-align:left;
+}
+.credibility-matrix th{
+  font-size:0.95rem;
+  font-weight:700;
+  color:#111827;
+}
+.credibility-matrix td{
+  font-size:0.95rem;
+  color:#1f2933;
+  font-weight:500;
+}
+.credibility-matrix tbody tr:last-child td{
+  border-bottom:none;
+}
+.credibility-note{
+  margin:0.75rem 0 0 0;
+  color:#475569;
+  font-size:0.9rem;
+  line-height:1.5;
+}
+.character-select-container{
+  max-width:960px;
+  margin:2rem auto;
+  padding:0 1.5rem 3rem 1.5rem;
+}
+.character-select-container h1{
+  font-size:2.4rem;
+  margin-bottom:1rem;
+  text-align:center;
+}
+.character-timing{
+  margin:0 auto 1rem auto;
+  max-width:760px;
+  text-align:center;
+  font-weight:600;
+  color:#1e293b;
+}
+.character-options{
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+  margin-top:1.5rem;
+}
+.character-option{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:1rem 1.25rem;
+  border-radius:14px;
+  background:#ffffff;
+  box-shadow:0 12px 28px rgba(15,23,42,0.08);
+}
+.character-input{
+  display:flex;
+  align-items:center;
+  gap:0.85rem;
+}
+.character-option input[type='radio']{
+  width:20px;
+  height:20px;
+}
+.character-option label{
+  cursor:pointer;
+  font-weight:600;
+  font-size:1.05rem;
+  color:#111827;
+  display:flex;
+  flex-direction:column;
+}
+.character-credibility{
+  margin-top:0.25rem;
+  font-size:0.85rem;
+  color:#475569;
+  font-weight:500;
+}
+.character-option a{
+  font-size:0.9rem;
+  color:#1d4ed8;
+  font-weight:600;
+  text-decoration:none;
+}
+.character-option a:hover{
+  text-decoration:underline;
+}
+.character-select-actions{
+  display:flex;
+  gap:1rem;
+  flex-wrap:wrap;
+  justify-content:center;
+  margin-top:1.75rem;
+}
+.character-select-actions button{
+  font-size:1rem;
+}
+.state-container.character-select{
+  margin-top:3rem;
+}
+.landing-page h1{
+  margin:2rem auto 1rem auto;
+  text-align:center;
+  font-size:2.4rem;
+}
+.mode-container{
+  display:flex;
+  flex-direction:column;
+  min-height:90vh;
+}
+.mode-panel{
+  flex:1;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:3rem 1.5rem;
+}
+.mode-panel:first-child{
+  background:linear-gradient(180deg,#eef2ff 0%,#ffffff 100%);
+}
+.mode-panel:last-child{
+  background:linear-gradient(180deg,#fff7ed 0%,#ffffff 100%);
+  border-top:1px solid #e0e7ff;
+}
+.mode-content{
+  max-width:540px;
+  text-align:center;
+}
+.mode-tag{
+  display:inline-block;
+  margin-bottom:0.75rem;
+  padding:0.4rem 1rem;
+  border-radius:999px;
+  font-weight:600;
+  font-size:0.9rem;
+  background:rgba(29,78,216,0.12);
+  color:#1d4ed8;
+}
+.mode-content h2{
+  margin:0 0 0.75rem 0;
+  font-size:2rem;
+}
+.mode-content p{
+  margin:0 0 1.5rem 0;
+  line-height:1.6;
+  font-size:1.05rem;
+}
+.mode-actions a,.mode-actions button{
+  display:inline-block;
+  padding:0.75rem 1.75rem;
+  font-size:1rem;
+  border-radius:999px;
+  border:none;
+  background:#1d4ed8;
+  color:#fff;
+  text-decoration:none;
+  cursor:pointer;
+  box-shadow:0 10px 24px rgba(29,78,216,0.15);
+}
+.mode-actions a.secondary,.mode-actions button.secondary{
+  background:#334155;
+}
+.campaign-container{
+  max-width:960px;
+  margin:2rem auto;
+  color:#1f2933;
+}
+.campaign-header{
+  background:#ffffff;
+  border-radius:16px;
+  padding:2rem;
+  box-shadow:0 14px 32px rgba(15,23,42,0.08);
+  margin-bottom:2rem;
+}
+.campaign-header h1{
+  margin:0 0 0.5rem 0;
+  font-size:2.2rem;
+}
+.campaign-header p{
+  margin:0.5rem 0 0 0;
+  line-height:1.6;
+  font-size:1.05rem;
+}
+.campaign-summary{
+  margin-bottom:2rem;
+}
+.sector-grid{
+  display:flex;
+  flex-wrap:wrap;
+  gap:1.5rem;
+}
+.sector-card{
+  flex:1 1 280px;
+  background:#ffffff;
+  border-radius:14px;
+  padding:1.75rem;
+  box-shadow:0 12px 28px rgba(15,23,42,0.07);
+}
+.sector-card h2{
+  margin:0;
+  font-size:1.4rem;
+}
+.sector-card p{
+  margin:0.75rem 0 0 0;
+  line-height:1.5;
+}
+.sector-card ul{
+  margin:0.75rem 0 1.25rem 1.25rem;
+  line-height:1.5;
+}
+.sector-card form{
+  margin-top:1.25rem;
+}
+.sector-card button{
+  padding:0.7rem 1.6rem;
+  border:none;
+  border-radius:999px;
+  background:#1d4ed8;
+  color:#fff;
+  font-size:1rem;
+  cursor:pointer;
+  box-shadow:0 10px 24px rgba(29,78,216,0.15);
+}
+.sector-player-preview{
+  margin-top:1.25rem;
+  display:flex;
+  align-items:center;
+  gap:0.85rem;
+  padding:0.85rem 1rem;
+  border-radius:14px;
+  background:#f8fafc;
+  border:1px solid #e2e8f0;
+  box-shadow:0 8px 20px rgba(15,23,42,0.05);
+}
+.sector-player-preview .preview-photo{
+  width:56px;
+  height:56px;
+  border-radius:50%;
+  overflow:hidden;
+  background:#e0e7ff;
+  color:#1d4ed8;
+  font-weight:700;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+.sector-player-preview .preview-photo img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  border-radius:50%;
+}
+.sector-player-preview-text{
+  display:flex;
+  flex-direction:column;
+  gap:0.25rem;
+}
+.sector-player-preview-text .preview-name{
+  margin:0;
+  font-weight:600;
+  color:#0f172a;
+}
+.sector-player-preview-text a{
+  color:#1d4ed8;
+  font-weight:600;
+  text-decoration:none;
+}
+.sector-player-preview-text a:hover{
+  text-decoration:underline;
+}
+.sector-player-preview-wrapper{
+  margin-top:1.5rem;
+}
+.sector-player-preview-wrapper h3{
+  margin:0 0 0.6rem 0;
+  font-size:0.95rem;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  color:#475569;
+}
+.campaign-summary-list{
+  list-style:none;
+  padding:0;
+  margin:0;
+  display:grid;
+  gap:1rem;
+}
+.campaign-summary-list li{
+  background:#ffffff;
+  border-radius:12px;
+  padding:1.25rem;
+  box-shadow:0 12px 28px rgba(15,23,42,0.07);
+}
+.campaign-summary-list h3{
+  margin:0 0 0.5rem 0;
+  font-size:1.2rem;
+}
+.campaign-summary-list p{
+  margin:0.25rem 0;
+  line-height:1.5;
+}
+.campaign-actions{
+  margin-top:2rem;
+  display:flex;
+  gap:1rem;
+  flex-wrap:wrap;
+}
+.instructions,.config-settings{
+  margin:1rem 0;
+  padding:1rem;
+  border:1px solid #dcdcdc;
+  border-radius:10px;
+  background:#f8faff;
+}
+.config-page{
+  max-width:960px;
+  margin:2rem auto;
+  padding:0 1.5rem 3rem 1.5rem;
+}
+.instructions h2,.config-settings h2{
+  margin-top:0;
+  margin-bottom:0.5rem;
+}
+.instructions ul{
+  margin:0.5rem 0 0 1.25rem;
+}
+.instructions li{
+  margin-bottom:0.4rem;
+}
+.config-settings form{
+  display:flex;
+  flex-direction:column;
+  gap:0.75rem;
+  max-width:360px;
+}
+.config-settings label{
+  display:flex;
+  flex-direction:column;
+  font-weight:600;
+  font-size:0.95rem;
+  gap:0.35rem;
+}
+.config-label-text{
+  display:flex;
+  align-items:center;
+  gap:0.4rem;
+}
+.config-settings input,.config-settings select{
+  margin-top:0.25rem;
+  padding:0.45rem;
+  border:1px solid #c6c6c6;
+  border-radius:6px;
+  font-size:0.95rem;
+}
+.config-settings button{
+  align-self:flex-start;
+  padding:0.45rem 0.9rem;
+  font-size:0.95rem;
+}
+.config-error{
+  margin:0 0 0.75rem 0;
+  padding:0.75rem;
+  border:1px solid #d93025;
+  background:#fdecea;
+  color:#a50e0e;
+  border-radius:8px;
+  font-size:0.9rem;
+}
+.config-note{
+  margin:0;
+  font-size:0.85rem;
+  color:#555;
+}
+.scenario-summary{
+  margin:1.5rem 0;
+  padding:1rem;
+  border:1px solid #dcdcdc;
+  border-radius:10px;
+  background:#f8f8f8;
+}
+.scenario-summary h2{
+  margin:0 0 0.5rem 0;
+  font-size:1.2rem;
+}
+.scenario-summary p{
+  margin:0.5rem 0;
+  line-height:1.5;
+}
+.result-page{
+  max-width:960px;
+  margin:2rem auto;
+  padding:0 1.5rem 3rem 1.5rem;
+  text-align:center;
+}
+.result-page form{
+  margin-top:1.5rem;
+}

--- a/web/tooltips.yaml
+++ b/web/tooltips.yaml
@@ -1,0 +1,19 @@
+attribute_tooltips:
+  leadership: "Leadership captures how well you coordinate allies and keep coalitions focused on shared commitments."
+  technology: "Technology reflects your technical literacy for evaluating safeguards and translating expert findings."
+  policy: "Policy measures your ability to craft enforceable agreements and navigate governance trade-offs."
+  network: "Network gauges access to relationships that unlock cooperation and surface new opportunities."
+credibility: >-
+  Credibility measures how much latitude this faction gives you. High scores lower reroll costs and keep
+  triplet-aligned commitments on the table. When credibility drops below the triplet cost, the faction stops
+  collaborating and only pushes its own agenda.
+config_field_help:
+  scenario: "Select the narrative scenario used for free play sessions."
+  win_threshold: "Score needed to achieve a win at the end of the run."
+  max_rounds: "Maximum number of conversation rounds before the game ends."
+  roll_success_threshold: "Minimum roll total required for an action to succeed."
+  action_time_cost_years: "Years of in-game time that pass whenever you attempt an action."
+  format_prompt_character_limit: "Maximum characters allowed when prompts are formatted for the model."
+  conversation_force_action_after: "Force an action to be offered after this many exchanges without one."
+  enabled_factions: "Factions that can appear in free play encounters."
+  player_faction: "Faction alignment assigned to your player character."


### PR DESCRIPTION
## Summary
- load tooltip copy, footer markup, and roll/state snippets from the new `web/` directory and wire them into `web_service.py`
- serve a shared `/web/style.css` file and rework each route to render through a common helper so every page picks up the global styles and footer
- move the tooltip text into `web/tooltips.yaml` so it can be tweaked without editing Python code

## Testing
- python -m compileall web_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a52d26e108333815282c59aa3d569)