### PR TITLE
Improve personas, faction info, and victory handling

### DIFF
--- a/web/snippets/state_refresh.js
+++ b/web/snippets/state_refresh.js
@@ -18,6 +18,25 @@ document.addEventListener('DOMContentLoaded', function () {
   let version = readVersion();
   let pending = readPending();
   let timer = null;
+  let redirected = false;
+  const shouldRedirectToVictory = function (payload) {
+    if (redirected || window.location.pathname === '/start') {
+      return false;
+    }
+    if (!payload || typeof payload !== 'object') {
+      return false;
+    }
+    if (payload.assessment_pending) {
+      return false;
+    }
+    if (
+      typeof payload.final_score === 'number' &&
+      typeof payload.win_threshold === 'number'
+    ) {
+      return payload.final_score >= payload.win_threshold;
+    }
+    return false;
+  };
   const applyHtml = function (html) {
     container.innerHTML = html;
     root = findRoot();
@@ -47,6 +66,11 @@ document.addEventListener('DOMContentLoaded', function () {
           if (changedVersion || changedPending || !root) {
             applyHtml(data.state_html);
           }
+        }
+        if (shouldRedirectToVictory(data)) {
+          redirected = true;
+          window.location.href = '/start';
+          return;
         }
         if (typeof data.progress_version === 'number') {
           version = data.progress_version;

--- a/web/style.css
+++ b/web/style.css
@@ -448,6 +448,11 @@ body.page-profile{
 .faction-detail h1,.faction-detail h2{
   margin-top:0;
 }
+.faction-subtitle{
+  margin:0.15rem 0 1rem 0;
+  font-weight:600;
+  color:#475569;
+}
 .faction-section ul{
   margin:0.75rem 0 0 1.25rem;
   line-height:1.6;
@@ -702,6 +707,35 @@ body.page-profile{
   text-align:center;
   font-weight:600;
   color:#1e293b;
+}
+.victory-banner{
+  margin:1rem auto 1.5rem auto;
+  max-width:780px;
+  padding:1.5rem 1.75rem;
+  border-radius:18px;
+  border:1px solid #bbf7d0;
+  background:linear-gradient(135deg,#ecfdf5,#d1fae5);
+  text-align:center;
+  box-shadow:0 18px 32px rgba(16,185,129,0.15);
+}
+.victory-banner h2{
+  margin:0 0 0.5rem 0;
+  color:#065f46;
+}
+.victory-banner p{
+  margin:0;
+  color:#064e3b;
+  font-weight:600;
+}
+.victory-actions{
+  display:flex;
+  justify-content:center;
+  gap:1rem;
+  flex-wrap:wrap;
+  margin-top:1.25rem;
+}
+.victory-actions a{
+  text-decoration:none;
 }
 .character-options{
   display:flex;


### PR DESCRIPTION
## Summary
- add attribute tooltips to persona cards and use faction images on conversation/profile panels so portraits render correctly
- keep the campaign timer rolling between levels, surface victory directly on the character select screen, and trigger automatic redirects when the threshold is hit
- restore the faction detail directory and detail pages with complete dossiers and styling so “View/Browse faction details” no longer throw 500 errors

## Testing
- `python -m compileall web_service.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ba8f6d81c8333b1e92cbc91107fd2)