### PR TITLE
Fix baseline context indentation

### DIFF
--- a/rpg/assessment_agent.py
+++ b/rpg/assessment_agent.py
@@ -121,6 +121,7 @@ class AssessmentAgent:
             baseline_context = cache_instruction
         else:
             # TODO: instead of "Reference material" call this section "# *FACTS TO BASE THE ASSESSMENT ON*". and make this change consistent across other branches, including caching
+            baseline_context = (
                 f"Reference material:\n{reference_block}\n"
                 f"Assess all triplets for {char.progress_label} using the context below:\n{context}\n"
             )


### PR DESCRIPTION
## Summary
- restore missing baseline_context assignment in the assessment agent when cache is unavailable, fixing indentation error

## Testing
- GEMINI_API_KEY=dummy python -m pytest -k "not test_genai_example"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f2749e9788333849bf0cd71e87099)