### PR TITLE
Handle secure flag for session cookie behind proxies

### DIFF
--- a/web_service.py
+++ b/web_service.py
@@ -619,11 +619,14 @@ def create_app() -> Flask:
     @app.after_request
     def _persist_session_cookie(response: Response) -> Response:
         if getattr(g, "session_cookie_new", False):
+            forwarded_proto = request.headers.get("X-Forwarded-Proto", "").lower()
+            secure = request.is_secure or forwarded_proto == "https"
             response.set_cookie(
                 SESSION_COOKIE_NAME,
                 g.session_data.session_id,
                 httponly=True,
                 samesite="Lax",
+                secure=secure,
             )
         return response
 


### PR DESCRIPTION
## Summary
- ensure the session cookie respects HTTPS when requests arrive through a proxy by checking X-Forwarded-Proto

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f338719708333846a0c8408b99cad)