### PR TITLE
Add session handling tests

### DIFF
--- a/web_service.py
+++ b/web_service.py
@@ -2319,7 +2319,17 @@ def create_app() -> Flask:
 
     @app.route("/actions", methods=["GET", "POST"])
     def character_actions() -> Response:
-        char_id = int(request.values["character"])
+        raw_char_id = request.values.get("character")
+        if raw_char_id is None:
+            return redirect("/start")
+        try:
+            char_id = int(raw_char_id)
+        except (TypeError, ValueError):
+            return redirect("/start")
+        with state_lock:
+            character_count = len(game_state.characters)
+        if char_id < 0 or char_id >= character_count:
+            return redirect("/start")
         if request.method == "POST" and "response" in request.form:
             option = _option_from_payload(request.form["response"])
             with state_lock:


### PR DESCRIPTION
## Summary
- add tests to cover session cookie lifecycle and invalid action requests
- ensure actions endpoint redirects to start when accessed without a valid session

## Testing
- pytest tests/test_web_service.py -k SessionHandlingTest -vv

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f3cfae8d0833392946f491a148b90)