### PR TITLE
Refine assessment prompt formatting

### DIFF
--- a/rpg/assessment_agent.py
+++ b/rpg/assessment_agent.py
@@ -46,7 +46,6 @@ class AssessmentAgent:
     def _assess_single(
         self,
         char: Character,
-        faction_list: str,
         history_text: str,
     ) -> List[int]:
         """Assess ``char`` returning a list of progress scores.
@@ -55,15 +54,8 @@ class AssessmentAgent:
         executed in parallel using threads when requested by the caller.
         """
 
-        base_context = str(char.base_context or "")
         triplet_text = char._triplet_text()
-        # TODO: remove the base context, only leave the triplets. Make it consistent across all branches, including caching.
-        context = f"{base_context}\n{triplet_text}"
         reference_parts: List[str] = []
-        # TODO: skip scenario summary entirely
-        summary_text = getattr(char, "scenario_summary", "")
-        if summary_text:
-            reference_parts.append(f"Scenario summary:\n{summary_text}")
         quote_lines: List[str] = []
         for quote in getattr(char, "referenced_quotes", []) or []:
             text = str(quote or "").strip()
@@ -82,16 +74,11 @@ class AssessmentAgent:
         cache_instruction = ""
         if manager:
             cache_segments = [
-                f"Reference material for evaluation:\n{reference_block}"
+                f"# *FACTS TO BASE THE ASSESSMENT ON*\n{reference_block}"
             ]
-            base_context_clean = base_context.strip()
-            if base_context_clean:
-                cache_segments.append(
-                    f"Persona context for {char.progress_label}:\n{base_context_clean}"
-                )
             if triplet_text:
                 cache_segments.append(
-                    f"Triplet definitions for {char.progress_label}:\n{triplet_text}"
+                    f"# *TRIPLETS TO ASSESS*\n{triplet_text}"
                 )
             cache_hash = f"{abs(hash(reference_block)) & 0xFFFFFFFF:08x}"
             cache_key = re.sub(
@@ -100,7 +87,7 @@ class AssessmentAgent:
                 f"assessment-{char.progress_key}-{cache_hash}".lower(),
             )
             cache_instruction = (
-                "Use the cached reference material, persona context, and triplet definitions when computing progress scores.\n"
+                "Use the cached facts and triplet definitions when computing progress scores.\n"
             )
             try:
                 cache_config = manager.get_cached_config(
@@ -109,7 +96,7 @@ class AssessmentAgent:
                     texts=cache_segments,
                     system_instruction=(
                         "You are the Game Master for the 'Keep the future human' survival RPG. "
-                        "Reference the cached reference material, persona context, and triplet definitions when producing assessment scores."
+                        "Reference the cached facts and triplet definitions when producing assessment scores."
                     ),
                 )
             except Exception as exc:  # pragma: no cover - cache service failure
@@ -120,18 +107,18 @@ class AssessmentAgent:
         if cache_config is not None:
             baseline_context = cache_instruction
         else:
-            # TODO: instead of "Reference material" call this section "# *FACTS TO BASE THE ASSESSMENT ON*". and make this change consistent across other branches, including caching
             baseline_context = (
-                f"Reference material:\n{reference_block}\n"
-                f"Assess all triplets for {char.progress_label} using the context below:\n{context}\n"
+                f"# *FACTS TO BASE THE ASSESSMENT ON*\n{reference_block}\n\n"
+                f"# *TRIPLETS TO ASSESS*\n{triplet_text}\n"
             )
         prompt = (
             "You are the Game Master for the 'Keep the future human' survival RPG. Your goal is to assess how much the game has progressed."
             "The player is interacting with the characters and convinces them to take actions. "
-            f"Assess the progress for the following factions' 'initial state - end state - gap' triplets with a 0-100 integer: {faction_list}, " # TODO: only the current faction, not faction_list
+            f"Assess the progress for the following factions' 'initial state - end state - gap' triplets with a 0-100 integer: {char.progress_label} faction, "
             "based on the provided *FACTS* and the *PERFORMED ACTIONS* towards closing the gaps.\n"
             f"{baseline_context}"
-            f"Performed actions: {history_text}\n" # TODO: separate this with a heading "# *PERFORMED ACTIONS AIMED AT CLOSING THE GAPS*" accross all branches
+            "# *PERFORMED ACTIONS AIMED AT CLOSING THE GAPS*\n"
+            f"{history_text}\n"
             "\n# *OUTPUT CONSTRAINTS*\nOutput ONLY an ordered list of 0-100 integers one for each triplet line-by-line. For example, 0 means that no relevant actions have been performed for a triplet (i.e. still the 'initial state' stands), while ~50 means that the 'gap' has been reduced by a lot, but significant gap remains, finally 100 means that the performed actions equivalently describe the 'end state'."
         )
         logger.debug(
@@ -183,22 +170,17 @@ class AssessmentAgent:
         Returns:
             Mapping of character name to list of progress scores.
         """
-        faction_list = ", ".join(c.progress_label for c in characters)
         history_text = "\n".join(f"{label}: {act}" for label, act in history) or "None"
 
         if parallel:
             with ThreadPoolExecutor(max_workers=len(characters)) as executor:
                 future_map = {
-                    executor.submit(
-                        self._assess_single, char, faction_list, history_text
-                    ): char.progress_key
+                    executor.submit(self._assess_single, char, history_text): char.progress_key
                     for char in characters
                 }
                 return {name: fut.result() for fut, name in future_map.items()}
 
         results: Dict[str, List[int]] = {}
         for char in characters:
-            results[char.progress_key] = self._assess_single(
-                char, faction_list, history_text
-            )
+            results[char.progress_key] = self._assess_single(char, history_text)
         return results


### PR DESCRIPTION
## Summary
- remove persona context and scenario summary from the assessment prompt
- restructure facts, triplets, and performed actions sections to match the new format and focus on the current faction
- align cache configuration with the updated prompt sections

## Testing
- python -m compileall rpg/assessment_agent.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692234fa109c8333a451833c191ddf22)