### PR TITLE
Enhance roll visuals and add branding assets

### DIFF
--- a/assets/result-banner.svg
+++ b/assets/result-banner.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Keep the Future Human result banner placeholder</title>
+  <desc id="desc">A placeholder banner with geometric gradients for the result panel.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.9" />
+      <stop offset="50%" stop-color="#6366f1" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#0f172a" stop-opacity="0.95" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#a855f7" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#22d3ee" stop-opacity="0.45" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" rx="32" fill="url(#grad)" />
+  <circle cx="980" cy="110" r="180" fill="url(#accent)" />
+  <circle cx="180" cy="560" r="200" fill="url(#accent)" />
+  <rect x="70" y="120" width="480" height="160" rx="24" fill="#0b1224" opacity="0.6" />
+  <text x="110" y="190" fill="#e2e8f0" font-family="Inter, Arial, sans-serif" font-size="40" font-weight="700">Outcome Preview</text>
+  <text x="110" y="240" fill="#cbd5f5" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500">
+    Campaign summary and coalition result snapshot
+  </text>
+  <rect x="660" y="260" width="470" height="220" rx="26" fill="#0b1224" opacity="0.65" />
+  <text x="700" y="330" fill="#bfdbfe" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">Scoreboard placeholder</text>
+  <text x="700" y="370" fill="#cbd5f5" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="500">16:9 image • 1200 × 675 px</text>
+  <text x="700" y="410" fill="#cbd5f5" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="500">Swap this banner with a final illustration later.</text>
+</svg>

--- a/web/style.css
+++ b/web/style.css
@@ -11,6 +11,38 @@ body.page-landing{
 body.page-profile{
   background:#f3f4f8;
 }
+.brand-header{
+  display:flex;
+  align-items:center;
+  gap:1rem;
+  background:#ffffff;
+  border-radius:18px;
+  padding:1rem 1.25rem;
+  box-shadow:0 12px 28px rgba(15,23,42,0.08);
+  border:1px solid #e2e8f0;
+  margin-bottom:1.5rem;
+}
+.brand-logo{
+  width:140px;
+  max-width:30vw;
+  height:auto;
+  border-radius:14px;
+  box-shadow:0 14px 32px rgba(15,23,42,0.12);
+  object-fit:contain;
+  background:#ffffff;
+}
+.brand-title h1{
+  margin:0;
+  font-size:1.9rem;
+}
+.brand-subtitle{
+  margin:0 0 0.25rem 0;
+  color:#475569;
+  font-weight:700;
+  letter-spacing:0.05em;
+  text-transform:uppercase;
+  font-size:0.85rem;
+}
 .global-footer{
   max-width:960px;
   margin:3rem auto 2rem;
@@ -220,6 +252,61 @@ body.page-profile{
   color:#9c2f2f;
   font-weight:600;
 }
+.roll-visual{
+  background:#f8fafc;
+  border:1px solid #e2e8f0;
+  border-radius:16px;
+  padding:1rem;
+  box-shadow:0 10px 24px rgba(15,23,42,0.06);
+  margin:0.75rem 0 1rem 0;
+}
+.roll-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(170px,1fr));
+  gap:1rem;
+}
+.roll-card{
+  background:#ffffff;
+  border-radius:14px;
+  border:1px solid #e2e8f0;
+  padding:0.75rem;
+  text-align:center;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:center;
+  min-height:220px;
+  box-shadow:0 12px 28px rgba(15,23,42,0.08);
+}
+.roll-card .roll-number{
+  font-size:2.2rem;
+  font-weight:800;
+  color:#0f172a;
+}
+.roll-card .roll-label,.roll-card figcaption{
+  margin-top:0.45rem;
+  color:#475569;
+  font-weight:700;
+}
+.die-card img{
+  width:100%;
+  max-width:180px;
+  height:170px;
+  object-fit:contain;
+}
+.roll-outcome{
+  font-weight:800;
+}
+.roll-outcome.success-text{
+  color:#0f766e;
+}
+.roll-outcome.failure-text{
+  color:#b91c1c;
+}
+.credibility-text{
+  font-weight:600;
+  color:#0f172a;
+}
 .roll-indicator{
   display:none;
   align-items:center;
@@ -414,6 +501,20 @@ body.page-profile{
   width:32px;
   height:32px;
   object-fit:contain;
+}
+.result-banner{
+  margin:1.25rem 0;
+}
+.result-banner img{
+  width:100%;
+  max-width:1200px;
+  aspect-ratio:16/9;
+  border-radius:16px;
+  display:block;
+  margin:0 auto;
+  object-fit:cover;
+  box-shadow:0 14px 32px rgba(15,23,42,0.12);
+  border:1px solid #e2e8f0;
 }
 .loading-page{
   min-height:60vh;


### PR DESCRIPTION
## Summary
- add site branding with favicon, logo headers on landing and character selection, and a placeholder result banner asset
- render roll outcomes with d20 imagery, styled breakdown cards, and clearer success/failure emphasis
- refresh styles to support the new visuals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923090ce6b4833390f3997eed0cdc8b)