### PR TITLE
Improve roll UX and finalize campaign results

### DIFF
--- a/web/snippets/roll_indicator.js
+++ b/web/snippets/roll_indicator.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', function () {
   if (!indicator) {
     return;
   }
+  const DISPLAY_DURATION = 2000;
   let hideTimer = null;
   let finalizeTimer = null;
   const scheduleHide = function () {
@@ -25,17 +26,31 @@ document.addEventListener('DOMContentLoaded', function () {
     if (finalizeTimer) {
       window.clearTimeout(finalizeTimer);
     }
-    hideTimer = window.setTimeout(scheduleHide, 3200);
+    hideTimer = window.setTimeout(scheduleHide, DISPLAY_DURATION);
+  };
+  const delaySubmitWithIndicator = function (form, predicate) {
+    form.addEventListener('submit', function (event) {
+      if (predicate && !predicate()) {
+        return;
+      }
+      if (form.dataset.rollSubmitting === 'true') {
+        return;
+      }
+      event.preventDefault();
+      form.dataset.rollSubmitting = 'true';
+      showIndicator();
+      window.setTimeout(function () {
+        form.submit();
+      }, DISPLAY_DURATION);
+    });
   };
   document.querySelectorAll('form.roll-trigger').forEach(function (form) {
-    form.addEventListener('submit', showIndicator);
+    delaySubmitWithIndicator(form, function () { return true; });
   });
   document.querySelectorAll('form.options-form').forEach(function (form) {
-    form.addEventListener('submit', function () {
+    delaySubmitWithIndicator(form, function () {
       const selected = form.querySelector("input[name='response']:checked");
-      if (selected && selected.dataset && selected.dataset.kind === 'action') {
-        showIndicator();
-      }
+      return Boolean(selected && selected.dataset && selected.dataset.kind === 'action');
     });
   });
 });

--- a/web/style.css
+++ b/web/style.css
@@ -248,52 +248,63 @@ body.page-profile{
 .reroll-actions form,.action-outcome-actions form,.mode-actions form{
   margin:0;
 }
-.warning-text{
-  color:#9c2f2f;
-  font-weight:600;
-}
-.roll-visual{
-  background:#f8fafc;
-  border:1px solid #e2e8f0;
-  border-radius:16px;
-  padding:1rem;
-  box-shadow:0 10px 24px rgba(15,23,42,0.06);
-  margin:0.75rem 0 1rem 0;
-}
-.roll-grid{
-  display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(170px,1fr));
-  gap:1rem;
-}
-.roll-card{
-  background:#ffffff;
-  border-radius:14px;
-  border:1px solid #e2e8f0;
-  padding:0.75rem;
-  text-align:center;
-  display:flex;
-  flex-direction:column;
-  justify-content:center;
-  align-items:center;
-  min-height:220px;
-  box-shadow:0 12px 28px rgba(15,23,42,0.08);
-}
-.roll-card .roll-number{
-  font-size:2.2rem;
-  font-weight:800;
-  color:#0f172a;
-}
-.roll-card .roll-label,.roll-card figcaption{
-  margin-top:0.45rem;
-  color:#475569;
-  font-weight:700;
-}
-.die-card img{
-  width:100%;
-  max-width:180px;
-  height:170px;
-  object-fit:contain;
-}
+  .warning-text{
+    color:#9c2f2f;
+    font-weight:600;
+  }
+  .roll-visual{
+    background:#f8fafc;
+    border:1px solid #e2e8f0;
+    border-radius:16px;
+    padding:1rem;
+    box-shadow:0 10px 24px rgba(15,23,42,0.06);
+    margin:0.75rem 0 1rem 0;
+  }
+  .roll-sequence{
+    display:flex;
+    align-items:stretch;
+    justify-content:center;
+    gap:0.6rem;
+    flex-wrap:wrap;
+  }
+  .roll-card{
+    background:#ffffff;
+    border-radius:14px;
+    border:1px solid #e2e8f0;
+    padding:0.6rem;
+    text-align:center;
+    display:flex;
+    flex-direction:column;
+    justify-content:center;
+    align-items:center;
+    min-height:140px;
+    min-width:130px;
+    box-shadow:0 10px 22px rgba(15,23,42,0.07);
+  }
+  .roll-operator{
+    font-size:1.35rem;
+    font-weight:700;
+    color:#1f2937;
+    align-self:center;
+    padding:0 0.35rem;
+  }
+  .roll-card .roll-number{
+    font-size:2.2rem;
+    font-weight:800;
+    color:#0f172a;
+  }
+  .roll-card .roll-label,
+  .roll-card figcaption{
+    margin-top:0.45rem;
+    color:#475569;
+    font-weight:700;
+  }
+  .die-card img{
+    width:100%;
+    max-width:120px;
+    height:120px;
+    object-fit:contain;
+  }
 .roll-outcome{
   font-weight:800;
 }

--- a/web_service.py
+++ b/web_service.py
@@ -955,7 +955,7 @@ def create_app() -> Flask:
         die_image_path = _die_image_path(roll_value)
         breakdown = (
             "<div class='roll-visual'>"
-            + "<div class='roll-grid'>"
+            + "<div class='roll-sequence'>"
             + (
                 "<figure class='roll-card die-card'>"
                 + f"<img src='{die_image_path}' alt='d20 roll showing {roll_value:.0f}'>"
@@ -963,18 +963,21 @@ def create_app() -> Flask:
                 + f"<div class='roll-number'>{roll_value:.0f}</div>"
                 + "</figure>"
             )
+            + "<div class='roll-operator' aria-hidden='true'>+</div>"
             + (
                 "<div class='roll-card'>"
                 + f"<div class='roll-number'>{attempt.effective_score:.0f}</div>"
                 + f"<div class='roll-label'>{escape(attribute_label, False)} modifier</div>"
                 + "</div>"
             )
+            + "<div class='roll-operator' aria-hidden='true'>=</div>"
             + (
                 "<div class='roll-card'>"
                 + f"<div class='roll-number'>{total:.0f}</div>"
                 + "<div class='roll-label'>Final value</div>"
                 + "</div>"
             )
+            + "<div class='roll-operator' aria-hidden='true'>/</div>"
             + (
                 "<div class='roll-card'>"
                 + f"<div class='roll-number'>{roll_threshold:.0f}</div>"
@@ -1875,7 +1878,9 @@ def create_app() -> Flask:
                 "<a class='primary-button' href='/result'>View detailed summary</a>",
             ]
             if current_mode == "campaign":
-                actions.append("<a class='secondary' href='/campaign/level'>Plan next sector</a>")
+                actions.append(
+                    "<a class='primary-button secondary' href='/campaign/level'>Plan next sector</a>"
+                )
             else:
                 actions.append("<a class='secondary' href='/'>Return to landing</a>")
             actions.append("</div>")
@@ -2441,11 +2446,7 @@ def create_app() -> Flask:
         attribute_label = escape(attempt.attribute or "none", False)
         success_text = (
             "<strong class='roll-outcome success-text'>Success!</strong> "
-            + f"Succeeded {escape(attempt.label, False)} "
-            + (
-                f"(attribute {attribute_label}: {attempt.effective_score}, "
-                f"roll={attempt.roll:.0f}, total={total:.0f}, threshold={roll_threshold})"
-            )
+            + f"Succeeded {escape(attempt.label, False)}."
         )
         credibility_delta = (
             -attempt.credibility_cost
@@ -2523,10 +2524,7 @@ def create_app() -> Flask:
         if custom_failure:
             failure_detail = escape(custom_failure, False)
         else:
-            failure_detail = (
-                f"Failed {escape(attempt.label, False)} (attribute {attribute_label}: {attempt.effective_score}, "
-                f"roll={attempt.roll:.0f}, total={total:.0f}, threshold={roll_threshold})"
-            )
+            failure_detail = f"Failed {escape(attempt.label, False)}."
         failure_text = f"<strong class='roll-outcome failure-text'>Failure.</strong> {failure_detail}"
         if next_cost > 0:
             reroll_note = f"Reroll will cost {next_cost} credibility."
@@ -3333,8 +3331,8 @@ def create_app() -> Flask:
                 + "</form>"
                 + "</main>"
             )
-        _finalize_db_run(session, outcome=outcome, successful=is_win)
-        return _render_page(body)
+            _finalize_db_run(session, outcome=outcome, successful=is_win)
+            return _render_page(body)
 
         level_index, scenario_key, sector_choice = campaign_context
         level_number = level_index + 1


### PR DESCRIPTION
## Summary
- ensure campaign results finalize database runs correctly before rendering
- restyle campaign planning link and roll visualizations for consistent layout and clearer calculation cues
- adjust roll indicator timing to show the animation for two seconds on first actions as well as rerolls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692379131f408333b5683ac08aff911c)