### PR TITLE
Ensure state polling keeps session cookie

### DIFF
--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -39,6 +39,19 @@ def _load_test_character() -> YamlCharacter:
 
 
 class WebServiceTest(unittest.TestCase):
+    def test_state_refresh_sends_session_cookie(self):
+        """The state polling script must include credentials for session reuse."""
+
+        snippet_path = (
+            Path(__file__).resolve().parent.parent
+            / "web"
+            / "snippets"
+            / "state_refresh.js"
+        )
+        with open(snippet_path, "r", encoding="utf-8") as fh:
+            contents = fh.read()
+        self.assertIn("credentials: 'include'", contents)
+
     def test_scenario_dropdown_lists_all_yaml_files(self):
         scenario_dir = Path(__file__).resolve().parent.parent / "scenarios"
         expected_values = {p.stem.lower() for p in scenario_dir.glob("*.yaml")}

--- a/web/snippets/state_refresh.js
+++ b/web/snippets/state_refresh.js
@@ -54,7 +54,12 @@ document.addEventListener('DOMContentLoaded', function () {
     timer = window.setTimeout(poll, delay);
   };
   const poll = function () {
-    fetch('/state', { headers: { Accept: 'application/json' } })
+    fetch('/state', {
+      headers: { Accept: 'application/json' },
+      // Ensure the session cookie is always sent, even when the page is
+      // embedded or fetched from a different host (e.g., via a tunnel).
+      credentials: 'include',
+    })
       .then(function (response) {
         if (!response.ok) {
           throw new Error('Bad response');


### PR DESCRIPTION
## Summary
- send credentials with the state polling fetch so the session cookie is reused and the game state is not reinitialized in a loop
- add regression test to confirm the state refresh script preserves session cookies

## Testing
- pytest tests/test_web_service.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a26c7e1a8833380f3a48d4b472d77)