### PR TITLE
Add game execution UUID integration test

### DIFF
--- a/evaluations/game_database.py
+++ b/evaluations/game_database.py
@@ -72,7 +72,7 @@ class GameDatabaseRecorder(GameRunObserver):
     ) -> None:
         self._connector = connector
         self._notes = notes
-        self._execution_id: int | None = None
+        self._execution_id: str | None = None
         self._session_id: str | None = None
         self._pre_turn_snapshot: Dict[str, list[int]] | None = None
         self._cached_credibility_targets: Iterable[str] | None = None
@@ -228,7 +228,7 @@ class GameDatabaseRecorder(GameRunObserver):
     def _snapshot_progress(self, state: GameState) -> Dict[str, list[int]]:
         return {key: list(values) for key, values in state.progress.items()}
 
-    def _record_action(self, state: GameState, attempt: ActionAttempt, round_index: int) -> int:
+    def _record_action(self, state: GameState, attempt: ActionAttempt, round_index: int) -> str:
         option_payload = attempt.option.to_payload()
         data: MutableMapping[str, object] = {
             "execution_id": self._execution_id,
@@ -253,7 +253,7 @@ class GameDatabaseRecorder(GameRunObserver):
         }
         return self._connector.insert_action(data)
 
-    def _record_assessment(self, state: GameState, action_id: int) -> None:
+    def _record_assessment(self, state: GameState, action_id: str) -> None:
         if self._faction_triplet_counts is None:
             self._faction_triplet_counts = {
                 faction: len(scores)
@@ -281,7 +281,7 @@ class GameDatabaseRecorder(GameRunObserver):
         }
         self._connector.insert_assessment(assessment_data)
 
-    def _record_credibility(self, state: GameState, attempt: ActionAttempt, action_id: int) -> None:
+    def _record_credibility(self, state: GameState, attempt: ActionAttempt, action_id: str) -> None:
         snapshot = state.credibility.snapshot()
         player_row = snapshot.get(state.player_faction, {})
         if self._cached_credibility_targets is None:

--- a/evaluations/sqlite3_db.ddl
+++ b/evaluations/sqlite3_db.ddl
@@ -2,7 +2,7 @@ PRAGMA foreign_keys = ON;
 
 -- 1) Game execution info (one row per run)
 CREATE TABLE IF NOT EXISTS executions (
-  execution_id                    INTEGER PRIMARY KEY,
+  execution_id                    TEXT PRIMARY KEY,
   session_id                      TEXT,
   player_class                    TEXT,
   automated_player_class          TEXT,
@@ -24,8 +24,8 @@ CREATE TABLE IF NOT EXISTS executions (
 
 -- 2) Actions recorded for an execution
 CREATE TABLE IF NOT EXISTS actions (
-  action_id             INTEGER PRIMARY KEY,
-  execution_id          INTEGER NOT NULL,
+  action_id             TEXT PRIMARY KEY,
+  execution_id          TEXT NOT NULL,
   session_id            TEXT,
   actor                 TEXT,
   title                 TEXT,
@@ -50,9 +50,9 @@ CREATE TABLE IF NOT EXISTS actions (
 
 -- 3) Assessments recorded after each action
 CREATE TABLE IF NOT EXISTS assessments (
-  assessment_id         INTEGER PRIMARY KEY,
-  execution_id          INTEGER NOT NULL,
-  action_id             INTEGER NOT NULL,
+  assessment_id         TEXT PRIMARY KEY,
+  execution_id          TEXT NOT NULL,
+  action_id             TEXT NOT NULL,
   session_id            TEXT,
   scenario              TEXT,
   final_weighted_score  INTEGER,
@@ -66,9 +66,9 @@ CREATE INDEX IF NOT EXISTS idx_assessments_exec_action
 
 -- 4) Credibility snapshots per action
 CREATE TABLE IF NOT EXISTS credibility (
-  credibility_vector_id INTEGER PRIMARY KEY,
-  execution_id          INTEGER NOT NULL,
-  action_id             INTEGER NOT NULL,
+  credibility_vector_id TEXT PRIMARY KEY,
+  execution_id          TEXT NOT NULL,
+  action_id             TEXT NOT NULL,
   session_id            TEXT,
   cost                  INTEGER NOT NULL,
   reroll_attempt_count  INTEGER NOT NULL,
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS credibility (
 
 -- 5) Results recorded per execution
 CREATE TABLE IF NOT EXISTS results (
-  execution_id          INTEGER PRIMARY KEY,
+  execution_id          TEXT PRIMARY KEY,
   session_id            TEXT,
   successful_execution  INTEGER NOT NULL,
   result                TEXT,

--- a/tests/test_sqlite_game_execution.py
+++ b/tests/test_sqlite_game_execution.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cli_game import load_characters
+from evaluations.game_database import GameDatabaseRecorder
+from evaluations.player_manager import PlayerManager
+from evaluations.players import RandomPlayer
+from evaluations.sqlite3_connector import SQLiteConnector
+from rpg.assessment_agent import AssessmentAgent
+
+
+def _response_with_text(text: str) -> SimpleNamespace:
+    return SimpleNamespace(text=text)
+
+
+def test_game_execution_persists_uuid_relationships(tmp_path: Path) -> None:
+    db_path = tmp_path / "game.sqlite"
+    log_dir = tmp_path / "logs"
+
+    action_payload = {
+        "actions": [
+            {
+                "text": "Coordinate a multi-faction response.",
+                "type": "action",
+                "related-triplet": 1,
+                "related-attribute": "policy",
+            }
+        ]
+    }
+
+    mock_char_model = MagicMock()
+    mock_char_model.generate_content.return_value = _response_with_text(
+        json.dumps(action_payload)
+    )
+
+    mock_assess_model = MagicMock()
+    mock_assess_model.generate_content.return_value = _response_with_text(
+        "50\n50\n50\n50\n50"
+    )
+
+    with patch("rpg.character.genai") as mock_char_genai, patch(
+        "rpg.assessment_agent.genai"
+    ) as mock_assess_genai:
+        mock_char_genai.GenerativeModel.return_value = mock_char_model
+        mock_assess_genai.GenerativeModel.return_value = mock_assess_model
+
+        characters = load_characters(scenario_name="complete")
+        assessor = AssessmentAgent()
+        connector = SQLiteConnector(db_path=db_path)
+
+        def observer_factory(*_args) -> GameDatabaseRecorder:
+            return GameDatabaseRecorder(connector, notes="integration-test")
+
+        manager = PlayerManager(
+            characters,
+            assessor,
+            log_dir,
+            game_observer_factory=observer_factory,
+            scenario="complete",
+        )
+        manager.run_sequence("random", RandomPlayer(), games=1, rounds=1)
+        connector.close()
+
+    assert db_path.exists()
+
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+
+    execution_row = connection.execute(
+        "SELECT execution_id FROM executions"
+    ).fetchone()
+    assert execution_row is not None
+    execution_id = execution_row["execution_id"]
+    uuid.UUID(execution_id)
+
+    action_row = connection.execute(
+        "SELECT action_id, execution_id FROM actions"
+    ).fetchone()
+    assert action_row is not None
+    action_id = action_row["action_id"]
+    uuid.UUID(action_id)
+    assert action_row["execution_id"] == execution_id
+
+    assessment_row = connection.execute(
+        "SELECT execution_id, action_id FROM assessments"
+    ).fetchone()
+    assert assessment_row is not None
+    assert assessment_row["execution_id"] == execution_id
+    assert assessment_row["action_id"] == action_id
+
+    credibility_row = connection.execute(
+        "SELECT execution_id, action_id FROM credibility"
+    ).fetchone()
+    assert credibility_row is not None
+    assert credibility_row["execution_id"] == execution_id
+    assert credibility_row["action_id"] == action_id
+
+    result_row = connection.execute(
+        "SELECT execution_id FROM results"
+    ).fetchone()
+    assert result_row is not None
+    assert result_row["execution_id"] == execution_id
+
+    connection.close()


### PR DESCRIPTION
### Motivation
- Ensure the switch from integer autoincrement IDs to UUID text IDs works end-to-end and that FK cascade relationships remain intact.
- Validate that a real game execution flow (with Gemini API mocked) writes an on-disk SQLite DB and that generated UUIDs propagate through child tables.
- Provide a regression test covering `GameDatabaseRecorder` + `SQLiteConnector` integration when IDs are UUID strings.

### Description
- Use `TEXT` primary keys in the SQLite DDL for `executions`, `actions`, `assessments`, `credibility`, and `results` and keep `ON DELETE CASCADE` foreign keys.
- Update `SQLiteConnector` to generate UUIDs via a new `_ensure_uuid` helper, make `_execute_insert` accept a `return_value`, and have `insert_*` methods return `str` UUIDs.
- Update `GameDatabaseRecorder` to use `str` IDs throughout and propagate UUIDs when inserting actions, assessments, credibility snapshots, and results.
- Add a new integration test `tests/test_sqlite_game_execution.py` that runs a mocked Gemini-backed game via `PlayerManager`, then opens the created SQLite file and asserts UUID formatting and FK propagation across `executions`, `actions`, `assessments`, `credibility`, and `results` rows.

### Testing
- Ran `pytest tests/test_sqlite_game_execution.py` and it passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952bae6a3008333957781bc76a94f68)