### PR TITLE
Adjust backup scheduler defaults and simplify backup flow

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,5 +17,6 @@ PORT=7860
 # SQLite logging (evaluations + web)
 ENABLE_SQLITE_LOGGING=0
 EVALUATION_SQLITE_PATH=/var/lib/sqlite/main.db
+EVALUATION_SQLITE_BACKUP_PATH=/var/lib/sqlite/main.backup.db
 LOG_WEB_RUNS_TO_DB=0
 WEB_DB_NOTES=

--- a/evaluations/backup-scheduler-config.yaml
+++ b/evaluations/backup-scheduler-config.yaml
@@ -1,0 +1,6 @@
+enabled: true
+poll_interval_seconds: 15
+session_inactive_seconds: 60
+trigger:
+  type: closed_sessions_threshold
+  closed_sessions_threshold: 1

--- a/evaluations/backup_scheduler.py
+++ b/evaluations/backup_scheduler.py
@@ -1,0 +1,163 @@
+"""Backup scheduler for SQLite evaluation database."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+import yaml
+
+from rpg.session_monitor import SessionActivityMonitor, SessionActivitySnapshot
+
+logger = logging.getLogger(__name__)
+
+
+class BackupTriggerCondition(Protocol):
+    """Interface for backup trigger conditions."""
+
+    def should_trigger(self, snapshot: SessionActivitySnapshot) -> bool:
+        """Return ``True`` when a backup should be triggered."""
+
+
+@dataclass(frozen=True)
+class BackupSchedulerConfig:
+    enabled: bool = True
+    poll_interval_seconds: float = 30.0
+    session_inactive_seconds: float = 600.0
+    trigger_type: str = "closed_sessions_threshold"
+    closed_sessions_threshold: int = 5
+
+
+class ClosedSessionsThresholdCondition:
+    """Trigger when closed sessions since last backup reach a threshold."""
+
+    def __init__(self, threshold: int) -> None:
+        if threshold < 1:
+            raise ValueError("threshold must be >= 1")
+        self.threshold = threshold
+
+    def should_trigger(self, snapshot: SessionActivitySnapshot) -> bool:
+        return snapshot.closed_since_last_backup >= self.threshold
+
+
+def load_backup_scheduler_config(path: Path) -> BackupSchedulerConfig:
+    """Load backup scheduler configuration from a YAML file."""
+
+    if not path.exists():
+        logger.info("Backup scheduler config missing at %s; using defaults", path)
+        return BackupSchedulerConfig()
+    with path.open("r", encoding="utf-8") as fh:
+        payload = yaml.safe_load(fh) or {}
+    if not isinstance(payload, dict):
+        logger.info("Backup scheduler config at %s malformed; using defaults", path)
+        return BackupSchedulerConfig()
+    trigger = payload.get("trigger", {}) if isinstance(payload.get("trigger", {}), dict) else {}
+    return BackupSchedulerConfig(
+        enabled=bool(payload.get("enabled", True)),
+        poll_interval_seconds=float(payload.get("poll_interval_seconds", 30.0)),
+        session_inactive_seconds=float(payload.get("session_inactive_seconds", 600.0)),
+        trigger_type=str(trigger.get("type", "closed_sessions_threshold")),
+        closed_sessions_threshold=int(trigger.get("closed_sessions_threshold", 5)),
+    )
+
+
+def build_trigger(config: BackupSchedulerConfig) -> BackupTriggerCondition:
+    """Instantiate a trigger condition from configuration."""
+
+    if config.trigger_type == "closed_sessions_threshold":
+        return ClosedSessionsThresholdCondition(config.closed_sessions_threshold)
+    raise ValueError(f"Unknown trigger type {config.trigger_type!r}")
+
+
+def perform_sqlite_backup(db_path: Path, backup_path: Path) -> None:
+    """Run a VACUUM INTO backup for the SQLite database."""
+
+    if not db_path.exists():
+        raise FileNotFoundError(f"SQLite database not found at {db_path}")
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    if backup_path.exists():
+        backup_path.unlink()
+    connection = sqlite3.connect(db_path, timeout=30)
+    try:
+        connection.execute("VACUUM INTO ?", (str(backup_path),))
+    finally:
+        connection.close()
+
+
+class BackupScheduler:
+    """Poll session activity and trigger SQLite backups."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path,
+        backup_path: Path,
+        trigger: BackupTriggerCondition,
+        session_monitor: SessionActivityMonitor,
+        session_inactive_seconds: float,
+        poll_interval_seconds: float,
+    ) -> None:
+        self.db_path = db_path
+        self.backup_path = backup_path
+        self.trigger = trigger
+        self.session_monitor = session_monitor
+        self.session_inactive_seconds = session_inactive_seconds
+        self.poll_interval_seconds = poll_interval_seconds
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(target=self._run, name="backup-scheduler", daemon=True)
+        self._thread.start()
+        logger.info("Backup scheduler started")
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is None:
+            return
+        self._thread.join(timeout=5)
+        self._thread = None
+
+    def run_once(self) -> bool:
+        """Check triggers once and perform a backup if needed."""
+
+        self.session_monitor.close_inactive_sessions(self.session_inactive_seconds)
+        snapshot = self.session_monitor.snapshot()
+        if not self.trigger.should_trigger(snapshot):
+            return False
+        logger.info(
+            "Backup triggered after %d closed session(s); %d active session(s)",
+            snapshot.closed_since_last_backup,
+            snapshot.active_session_count,
+        )
+        perform_sqlite_backup(self.db_path, self.backup_path)
+        self.session_monitor.reset_for_backup()
+        return True
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self.run_once()
+            except Exception:
+                logger.exception("Backup scheduler encountered an error")
+            self._stop_event.wait(self.poll_interval_seconds)
+
+
+__all__ = [
+    "BackupScheduler",
+    "BackupSchedulerConfig",
+    "BackupTriggerCondition",
+    "ClosedSessionsThresholdCondition",
+    "build_trigger",
+    "load_backup_scheduler_config",
+    "perform_sqlite_backup",
+]

--- a/rpg/session_monitor.py
+++ b/rpg/session_monitor.py
@@ -1,0 +1,115 @@
+"""Session activity tracking for backup scheduling."""
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class SessionActivitySnapshot:
+    """Summary of session activity for backup triggers."""
+
+    active_session_count: int
+    closed_since_last_backup: int
+
+
+@dataclass
+class _SessionRecord:
+    session_id: str
+    last_access: float
+    created_generation: int
+    closed: bool = False
+
+
+class SessionActivityMonitor:
+    """Track active sessions and closed session counts for scheduling."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, _SessionRecord] = {}
+        self._closed_since_last_backup = 0
+        self._generation = 0
+        self._lock = threading.Lock()
+
+    def register_session(self, session_id: str, now: float | None = None) -> None:
+        """Register a new session for activity tracking."""
+
+        timestamp = now if now is not None else time.time()
+        with self._lock:
+            if session_id in self._sessions:
+                self._sessions[session_id].last_access = timestamp
+                return
+            self._sessions[session_id] = _SessionRecord(
+                session_id=session_id,
+                last_access=timestamp,
+                created_generation=self._generation,
+            )
+
+    def touch_session(self, session_id: str, now: float | None = None) -> None:
+        """Update session activity based on a new request."""
+
+        timestamp = now if now is not None else time.time()
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None:
+                self._sessions[session_id] = _SessionRecord(
+                    session_id=session_id,
+                    last_access=timestamp,
+                    created_generation=self._generation,
+                )
+                return
+            record.last_access = timestamp
+            if record.closed:
+                record.closed = False
+                record.created_generation = self._generation
+
+    def close_inactive_sessions(
+        self, inactive_for_seconds: float, now: float | None = None
+    ) -> list[str]:
+        """Mark inactive sessions as closed for backup counting."""
+
+        timestamp = now if now is not None else time.time()
+        closed_sessions: list[str] = []
+        with self._lock:
+            for record in self._sessions.values():
+                if record.closed:
+                    continue
+                if timestamp - record.last_access < inactive_for_seconds:
+                    continue
+                record.closed = True
+                closed_sessions.append(record.session_id)
+                if record.created_generation == self._generation:
+                    self._closed_since_last_backup += 1
+        return closed_sessions
+
+    def mark_closed(self, session_id: str) -> None:
+        """Explicitly mark a session as closed."""
+
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None or record.closed:
+                return
+            record.closed = True
+            if record.created_generation == self._generation:
+                self._closed_since_last_backup += 1
+
+    def snapshot(self) -> SessionActivitySnapshot:
+        """Return the current snapshot of session activity."""
+
+        with self._lock:
+            active = sum(1 for record in self._sessions.values() if not record.closed)
+            closed = self._closed_since_last_backup
+        return SessionActivitySnapshot(
+            active_session_count=active,
+            closed_since_last_backup=closed,
+        )
+
+    def reset_for_backup(self) -> None:
+        """Reset counters after a backup completes."""
+
+        with self._lock:
+            self._generation += 1
+            self._closed_since_last_backup = 0

--- a/tests/test_backup_scheduler_e2e.py
+++ b/tests/test_backup_scheduler_e2e.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import os
+import sys
+import time
+import sqlite3
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+with patch.dict("sys.modules", {"google.generativeai": MagicMock()}):
+    from web_service import create_app
+
+from evaluations.backup_scheduler import BackupSchedulerConfig
+from rpg.character import ResponseOption, YamlCharacter
+from rpg.config import GameConfig
+
+CHARACTERS_FILE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "characters.yaml"
+)
+SCENARIO_FILE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "scenarios", "complete.yaml"
+)
+
+
+def _load_test_character() -> YamlCharacter:
+    with open(CHARACTERS_FILE, "r", encoding="utf-8") as fh:
+        character_payload = yaml.safe_load(fh)
+    with open(SCENARIO_FILE, "r", encoding="utf-8") as fh:
+        faction_payload = yaml.safe_load(fh)
+    profile = character_payload["Characters"][0]
+    faction_spec = faction_payload[profile["faction"]]
+    return YamlCharacter(profile["name"], faction_spec, profile)
+
+
+def _post_action(client) -> None:
+    option = ResponseOption(
+        text="Coordinate oversight teams",
+        type="action",
+        related_triplet=1,
+        related_attribute="leadership",
+    )
+    payload = json.dumps(option.to_payload())
+    response = client.post(
+        "/actions",
+        data={"character": "0", "response": payload},
+    )
+    assert response.status_code == 200
+
+
+def test_backup_scheduler_e2e(tmp_path, monkeypatch):
+    db_path = tmp_path / "game.sqlite"
+    backup_path = tmp_path / "backup.sqlite"
+    monkeypatch.setenv("ENABLE_SQLITE_LOGGING", "1")
+    monkeypatch.setenv("LOG_WEB_RUNS_TO_DB", "1")
+    monkeypatch.setenv("EVALUATION_SQLITE_PATH", str(db_path))
+    monkeypatch.setenv("EVALUATION_SQLITE_BACKUP_PATH", str(backup_path))
+    sqlite3.connect(db_path).close()
+    test_config = GameConfig(
+        enabled_factions=("test_character", "CivilSociety", "ScientificCommunity")
+    )
+    backup_config = BackupSchedulerConfig(
+        enabled=True,
+        poll_interval_seconds=0.01,
+        session_inactive_seconds=0.01,
+        closed_sessions_threshold=2,
+    )
+    character = _load_test_character()
+
+    with patch("rpg.character.genai"), patch(
+        "rpg.assessment_agent.genai"
+    ), patch(
+        "web_service.load_characters", return_value=[character]
+    ), patch(
+        "web_service.current_config", test_config
+    ), patch(
+        "rpg.character.Character._generate_with_context",
+        return_value=SimpleNamespace(text="[]"),
+    ), patch(
+        "rpg.assessment_agent.AssessmentAgent.assess", return_value={}
+    ), patch(
+        "rpg.game_state.random.randint", return_value=20
+    ), patch(
+        "web_service.time.sleep", return_value=None
+    ), patch(
+        "web_service.load_backup_scheduler_config", return_value=backup_config
+    ), patch(
+        "web_service.WEB_LOG_TO_DB", True
+    ):
+        app = create_app()
+        client_one = app.test_client()
+        client_two = app.test_client()
+
+        client_one.get("/start")
+        _post_action(client_one)
+
+        client_two.get("/start")
+        _post_action(client_two)
+
+        scheduler = app.config["backup_scheduler"]
+        monitor = app.config["session_activity_monitor"]
+        assert scheduler is not None
+        assert monitor is not None
+        time.sleep(0.05)
+        monitor.close_inactive_sessions(
+            backup_config.session_inactive_seconds,
+            now=time.time() + 1,
+        )
+        assert scheduler.run_once() is True
+
+    assert backup_path.exists()


### PR DESCRIPTION
### Motivation
- Make the backup scheduler use a shorter poll interval and inactivity window and trigger more aggressively for quicker end-to-end testing.
- Treat the backup target path as persistent storage (e.g., mounted bucket) so no uploader/post-upload logic is needed.
- Ensure missing scheduler components or config are logged at `INFO` rather than `WARNING` to reduce false-positive log severity.
- Integrate lightweight session activity tracking so backups only run when sessions are inactive.

### Description
- Updated `evaluations/backup-scheduler-config.yaml` to `poll_interval_seconds: 15`, `session_inactive_seconds: 60`, and `closed_sessions_threshold: 1` and left `enabled: true`.
- Removed uploader abstraction and `EVALUATION_SQLITE_BACKUP_BUCKET_DIR` usage, so `BackupScheduler` now writes backups directly to the configured `EVALUATION_SQLITE_BACKUP_PATH` via `VACUUM INTO` in `perform_sqlite_backup`.
- Lowered log severity to `INFO` for missing/malformed config and invalid trigger cases, and changed scheduler startup/shutdown logs accordingly in `evaluations/backup_scheduler.py` and `web_service.py`.
- Added `rpg/session_monitor.py` and wired session registration/touching/closing into `web_service.py` so `BackupScheduler` uses `SessionActivityMonitor` for trigger decisions, and simplified the e2e test `tests/test_backup_scheduler_e2e.py` to assert backup file creation.

### Testing
- Ran the end-to-end test `pytest tests/test_backup_scheduler_e2e.py` which passed and verifies the backup file exists at the configured `EVALUATION_SQLITE_BACKUP_PATH`.
- Ran the full test suite with `pytest`, during which 28 tests passed before the run was interrupted by a `KeyboardInterrupt` stemming from an external retry loop in a Google API dependency, and the interruption prevented completion of the full run.
- No automated tests were removed; `tests/test_backup_scheduler_e2e.py` was updated to remove uploader assertions and now asserts only the backup file creation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ee629ff4833399e2c5d840e160e3)