### PR TITLE
Timestamp SQLite backups and directory handling

### DIFF
--- a/tests/test_backup_scheduler.py
+++ b/tests/test_backup_scheduler.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import sqlite3
+
+from evaluations.backup_scheduler import perform_sqlite_backup
+
+
+def test_perform_sqlite_backup_accepts_directory(tmp_path):
+    db_path = tmp_path / "game.sqlite"
+    backup_dir = tmp_path / "backups"
+    sqlite3.connect(db_path).close()
+
+    perform_sqlite_backup(db_path, backup_dir)
+
+    backup_files = list(backup_dir.glob("game-*.sqlite"))
+    assert len(backup_files) == 1

--- a/tests/test_backup_scheduler_e2e.py
+++ b/tests/test_backup_scheduler_e2e.py
@@ -54,7 +54,7 @@ def _post_action(client) -> None:
 
 def test_backup_scheduler_e2e(tmp_path, monkeypatch):
     db_path = tmp_path / "game.sqlite"
-    backup_path = tmp_path / "backup.sqlite"
+    backup_path = tmp_path / "backups"
     monkeypatch.setenv("ENABLE_SQLITE_LOGGING", "1")
     monkeypatch.setenv("LOG_WEB_RUNS_TO_DB", "1")
     monkeypatch.setenv("EVALUATION_SQLITE_PATH", str(db_path))
@@ -112,4 +112,5 @@ def test_backup_scheduler_e2e(tmp_path, monkeypatch):
         )
         assert scheduler.run_once() is True
 
-    assert backup_path.exists()
+    backup_files = list(backup_path.glob("game-*.sqlite"))
+    assert len(backup_files) == 1


### PR DESCRIPTION
### Motivation
- Prevent failures when the configured backup target is a directory or a suffixless path and avoid unlinking directories.
- Avoid overwriting existing backups by generating unique, timestamp-suffixed filenames.
- Treat suffixless backup paths as directory targets for convenience and clearer behavior.
- Provide bounded collision handling and explicit errors when a usable filename cannot be allocated.

### Description
- Implemented `_resolve_backup_path` to compute a timestamped backup file and to treat directories or suffixless paths as directory targets.
- Generate names of the form `stem-YYYYMMDDHHMMSS[-N].sqlite` with up to 100 attempts and raise `IsADirectoryError` or `FileExistsError` when appropriate.
- Updated `perform_sqlite_backup` to use the resolved backup file, create parent directories with `mkdir(..., exist_ok=True)`, and write via `VACUUM INTO` without unlinking existing files.
- Updated tests `tests/test_backup_scheduler.py` and `tests/test_backup_scheduler_e2e.py` to expect timestamped `game-*.sqlite` backup files.

### Testing
- No automated tests were executed in this rollout, so test status is currently unverified.
- The unit test `tests/test_backup_scheduler.py::test_perform_sqlite_backup_accepts_directory` was updated but not run.
- The end-to-end test `tests/test_backup_scheduler_e2e.py::test_backup_scheduler_e2e` was updated but not run.
- Run `pytest` after merging to validate the updated unit and integration tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f9ab92b483339c879ba7f0889d2e)