### PR TITLE
Fix quote escaping in backup scheduler

### DIFF
--- a/evaluations/backup_scheduler.py
+++ b/evaluations/backup_scheduler.py
@@ -119,7 +119,7 @@ def _resolve_backup_path(db_path: Path, backup_path: Path) -> Path:
 
 
 def _quote_identifier(identifier: str) -> str:
-    return f'"{identifier.replace("\"", "\"\"")}"'
+    return '"' + identifier.replace('"', '""') + '"'
 
 
 def _cleanup_sqlite_database(connection: sqlite3.Connection) -> None:


### PR DESCRIPTION
### Motivation
- Fix a SyntaxError caused by an invalid f-string escape in `_quote_identifier` that prevented `evaluations.backup_scheduler` from being imported. 
- Ensure SQLite identifiers are correctly quoted so `DROP TABLE IF EXISTS` and other generated SQL are valid for names containing double quotes. 
- Make the module importable at startup to avoid runtime crashes during service initialization.

### Description
- Replace the problematic f-string in `evaluations/backup_scheduler.py::_quote_identifier` with a concatenation implementation: `"'" + identifier.replace('"', '""') + '"'` so internal quotes are doubled without backslashes in an f-string. 
- Preserve behavior: identifiers are wrapped in double quotes and any internal `"` are doubled to `""` for SQLite compatibility. 
- Updated and committed the single file `evaluations/backup_scheduler.py` containing this fix.

### Testing
- No automated tests were run on this change.
- The change is limited and syntactic, so it should resolve the import-time `SyntaxError` immediately when the module is imported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695440d7c548833395b21496e30a61be)