### PR TITLE
Ignore default session in backup activity counts and preserve SQLite schema on backup cleanup

### DIFF
--- a/evaluations/backup_scheduler.py
+++ b/evaluations/backup_scheduler.py
@@ -130,7 +130,12 @@ def _cleanup_sqlite_database(connection: sqlite3.Connection) -> None:
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
         ).fetchall()
         for (table_name,) in rows:
-            connection.execute(f"DROP TABLE IF EXISTS {_quote_identifier(table_name)}")
+            connection.execute(f"DELETE FROM {_quote_identifier(table_name)}")
+        sequence_present = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'"
+        ).fetchone()
+        if sequence_present:
+            connection.execute("DELETE FROM sqlite_sequence")
     finally:
         if foreign_keys_enabled:
             connection.execute("PRAGMA foreign_keys = ON")

--- a/web_service.py
+++ b/web_service.py
@@ -577,7 +577,6 @@ def create_app() -> Flask:
     session_store: Dict[str, SessionData] = {default_session.session_id: default_session}
     session_store_lock = threading.Lock()
     session_activity_monitor = SessionActivityMonitor()
-    session_activity_monitor.register_session(default_session.session_id, now=now)
     backup_config_path = (
         Path(__file__).resolve().parent / "evaluations" / "backup-scheduler-config.yaml"
     )
@@ -822,7 +821,8 @@ def create_app() -> Flask:
     def _touch_session(session: SessionData, now: float | None = None) -> SessionData:
         timestamp = now or time.time()
         session.last_access = timestamp
-        session_activity_monitor.touch_session(session.session_id, now=timestamp)
+        if session.session_id != default_session.session_id:
+            session_activity_monitor.touch_session(session.session_id, now=timestamp)
         return session
 
     def _get_or_create_session(session_id: str | None) -> tuple[SessionData, bool]:


### PR DESCRIPTION
### Motivation
- Prevent the internal default session from being counted by the backup scheduler so activity counts and inactive-session logic reflect real user sessions.
- Preserve SQLite database schema when performing backups so runtime logging and table definitions are not lost.

### Description
- Stop registering the `default_session` with the `session_activity_monitor` by removing the initial `session_activity_monitor.register_session` call and skip touch calls for `default_session` inside `_touch_session`.
- Ensure `_touch_session` only calls `session_activity_monitor.touch_session` for non-default sessions by adding a session-id conditional check.
- Replace destructive `DROP TABLE` logic with `DELETE FROM` for all non-system tables during cleanup so table schemas remain intact.
- Reset autoincrement counters by deleting from `sqlite_sequence` when present while preserving `PRAGMA foreign_keys` handling during cleanup.

### Testing
- No automated unit tests were run for these changes.
- No continuous integration (CI) runs were triggered for this patch.
- No automated backup or database migration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69544746b6988333be2da46b798878a3)