### PR TITLE
Avoid logging "Campaign level restarted" on initial campaign level start

### DIFF
--- a/web_service.py
+++ b/web_service.py
@@ -1629,6 +1629,7 @@ def create_app() -> Flask:
             selected_sector = request.form.get("sector", "").strip().lower()
             if selected_sector not in {"public", "private"}:
                 return redirect("/campaign/level")
+            prior_sector = campaign_state.sector_choice
             campaign_state.sector_choice = selected_sector
             new_config = _campaign_config(level_index, selected_sector)
             logger.info(
@@ -1640,7 +1641,9 @@ def create_app() -> Flask:
                 _reload_state(
                     new_config,
                     preserve_time=True,
-                    completion_outcome="Campaign level restarted",
+                    completion_outcome=(
+                        "Campaign level restarted" if prior_sector is not None else None
+                    ),
                     completion_successful=False,
                 )
             return redirect("/start")


### PR DESCRIPTION
### Motivation
- The `/campaign/level` handler always finalized the previous DB run with the `"Campaign level restarted"` outcome when a sector was selected, causing a spurious result row even on the first level start.
- That behavior made normal campaign starts look like a restart in the results table.
- The intent is to only emit the `"Campaign level restarted"` entry when the player actually restarts or switches sector after an initial choice. 
- Keep the existing behavior of preserving time (`preserve_time=True`) when loading the chosen level.

### Description
- Added a `prior_sector` local variable in the `/campaign/level` POST handler to capture the previous `campaign_state.sector_choice` before updating it. 
- Only pass `completion_outcome="Campaign level restarted"` to `_reload_state` when `prior_sector is not None`, otherwise pass `None` to avoid recording a restart result on the initial selection. 
- Change is limited to `web_service.py` within the campaign level selection flow and does not alter other completion outcomes or DB logic. 

### Testing
- No automated tests were executed for this change.
- Existing automated test suites in the repository were not run as part of this change.
- Manual inspection of the change ensures it only conditions the `completion_outcome` argument and does not modify `_reload_state` semantics.
- Further automated or integration tests can be added to assert DB `results` rows for first-start vs restart scenarios if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695519517d948333afc0e229c7af4452)