### PR TITLE
Guard backups from active sessions and harden DB action recording

### DIFF
--- a/evaluations/backup_scheduler.py
+++ b/evaluations/backup_scheduler.py
@@ -206,6 +206,14 @@ class BackupScheduler:
 
         self.session_monitor.close_inactive_sessions(self.session_inactive_seconds)
         snapshot = self.session_monitor.snapshot()
+        if snapshot.closed_since_last_backup < 1:
+            return False
+        if snapshot.active_session_count > 0:
+            logger.info(
+                "Backup skipped; %d active session(s) remain",
+                snapshot.active_session_count,
+            )
+            return False
         if not self.trigger.should_trigger(snapshot):
             return False
         logger.info(


### PR DESCRIPTION
### Motivation

- Prevent the backup scheduler from performing a backup while there are still active sessions, which can cause race conditions with live writes.
- Ensure a backup only runs after at least one session has closed since the last backup (according to the session monitor trigger counting).
- Avoid crashing the game flow when a problematic DB insert (e.g. FOREIGN KEY constraint failure) occurs during turn persistence.
- Add tests to cover the skipped-backup and failed-action-insert scenarios.

### Description

- Require `snapshot.closed_since_last_backup >= 1` and skip backups when `snapshot.active_session_count > 0` in `BackupScheduler.run_once()` and log when skipping.
- Add defensive handling in `GameDatabaseRecorder.after_turn()` to catch `sqlite3.IntegrityError` on action inserts, log the error, skip persisting that turn, and continue without raising; also catch other `sqlite3.Error` cases when recording assessment/credibility and on commit and log them.
- Added `test_backup_scheduler_skips_when_active_sessions` to `tests/test_backup_scheduler.py` to verify backups are not performed while active sessions remain.
- Added `test_recorder_skips_action_on_integrity_error` to `tests/test_game_database_recorder.py` to verify the recorder logs and skips a failed action insert and does not attempt assessments/credibility or extra commits.

### Testing

- Ran the test suite with `pytest`; the test run executed and reported 32 tests passed before the CI run was interrupted (KeyboardInterrupt) during unrelated retry logic.
- The new unit tests `tests/test_backup_scheduler.py::test_backup_scheduler_skips_when_active_sessions` and `tests/test_game_database_recorder.py::test_recorder_skips_action_on_integrity_error` were executed and passed during the run.
- Existing backup tests (`tests/test_backup_scheduler.py`) and recorder unit tests continued to pass where executed.
- No failing automated tests were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695530977ed08333a545fb422a44464d)