### PR TITLE
Log player resets as successful executions

### DIFF
--- a/web_service.py
+++ b/web_service.py
@@ -1495,7 +1495,7 @@ def create_app() -> Flask:
                     _reload_state(
                         form_config,
                         completion_outcome="Free play restarted",
-                        completion_successful=False,
+                        completion_successful=True,
                     )
                 return redirect("/start")
 
@@ -1609,7 +1609,7 @@ def create_app() -> Flask:
             _reload_state(
                 load_game_config(),
                 completion_outcome="Campaign restarted",
-                completion_successful=False,
+                completion_successful=True,
             )
             config_snapshot = _session().config_in_use
         logger.info("Campaign started with baseline config %s", config_snapshot)
@@ -1644,7 +1644,7 @@ def create_app() -> Flask:
                     completion_outcome=(
                         "Campaign level restarted" if prior_sector is not None else None
                     ),
-                    completion_successful=False,
+                    completion_successful=True,
                 )
             return redirect("/start")
 


### PR DESCRIPTION
### Motivation
- Resets initiated by the player (free play, campaign restart, and campaign level restart) should be recorded in the results table as successful executions rather than errors.
- The results `successful_execution` column is used to indicate erroneous executions or unexpected events, and resets are not errors.

### Description
- Updated `web_service.py` to pass `completion_successful=True` when calling `_reload_state` for free play apply/start, campaign start, and campaign level restart.
- This change ensures the database recorder finalizes runs with `successful=True` so `successful_execution` is stored as `1` for player resets.
- Modified locations are the free play form submission, the `/campaign/start` handler, and the campaign level restart flow.

### Testing
- No automated tests were executed as part of this change.
- The change was limited to three boolean arguments in `web_service.py` and does not include additional unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69555af10c68833396ffec3caa539d57)