### PR TITLE
Defer DB execution creation until NPC selection (/start)

### DIFF
--- a/web_service.py
+++ b/web_service.py
@@ -487,6 +487,7 @@ class SessionData:
     db_game_index: int = 1
     db_result_recorded: bool = False
     db_logging_disabled: bool = False
+    db_run_pending: bool = False
 
 
 def _option_from_payload(raw: str) -> ResponseOption:
@@ -644,6 +645,7 @@ def create_app() -> Flask:
         session.db_result_recorded = False
         if increment_game:
             session.db_game_index += 1
+        session.db_run_pending = True
 
     def _start_db_run_for_session(session: SessionData) -> None:
         if session.db_logging_disabled or not WEB_LOG_TO_DB:
@@ -686,6 +688,13 @@ def create_app() -> Flask:
         session.db_recorder = recorder
         session.db_round_index = 0
         session.db_result_recorded = False
+        session.db_run_pending = False
+
+    def _maybe_start_db_run_for_session(session: SessionData) -> None:
+        if not session.db_run_pending:
+            return
+        _start_db_run_for_session(session)
+        session.db_run_pending = False
 
     def _db_before_turn(session: SessionData) -> int | None:
         if session.db_recorder is None or session.db_logging_disabled:
@@ -1168,7 +1177,6 @@ def create_app() -> Flask:
             session.assessment_threads.clear()
         session.last_history_signature = None
         _reset_db_logging_state(session, increment_game=True)
-        _start_db_run_for_session(session)
 
     def _format_summary_html(text: str) -> str:
         stripped = (text or "").strip()
@@ -1813,6 +1821,7 @@ def create_app() -> Flask:
             and campaign_state.sector_choice is None
         ):
             return redirect("/campaign/level")
+        _maybe_start_db_run_for_session(session)
         with state_lock:
             score = game_state.final_weighted_score()
             hist_len = len(game_state.history)


### PR DESCRIPTION
### Motivation
- Avoid creating a DB `execution` entry on every call to `_reload_state` and instead create it only when the NPC selection page (`/start`) is actually loaded. 
- Ensure free play start, campaign level starts, and resets mark a new game run but postpone DB work until the first NPC selection view. 
- Reduce spurious DB entries and handle cases where a reload/reset should not immediately begin a logged execution. 

### Description
- Add a `db_run_pending` flag to `SessionData` to mark that a DB run should be started later. 
- Mark runs as pending by setting `session.db_run_pending = True` inside `_reset_db_logging_state` (used for restarts/resets/config changes). 
- Stop calling `_start_db_run_for_session` from `_reload_state` and instead add `_maybe_start_db_run_for_session` which invokes `_start_db_run_for_session` only when `db_run_pending` is true. 
- Call `_maybe_start_db_run_for_session(session)` at the top of the `/start` handler so the DB execution is created when the NPC selection screen loads. 

### Testing
- No automated tests were executed as part of this change. 
- Existing unit tests that reference `GameDatabaseRecorder` remain present in the test tree but were not run here. 
- Manual inspection and repository-wide grep were used to locate DB start points and update the reload/start call sites. 
- No regressions from automated runs are reported in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695983b99710833396db441a3d6f19cb)