### PR TITLE
Avoid duplicate backups when cleanup retries and add robust write-lock handling

### DIFF
--- a/evaluations/backup_scheduler.py
+++ b/evaluations/backup_scheduler.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
 import threading
@@ -15,6 +16,7 @@ from typing import Protocol
 import yaml
 
 from rpg.session_monitor import SessionActivityMonitor, SessionActivitySnapshot
+from .sqlite3_connector import DatabaseLockedError, sqlite_write_lock
 
 logger = logging.getLogger(__name__)
 
@@ -78,9 +80,7 @@ def build_trigger(config: BackupSchedulerConfig) -> BackupTriggerCondition:
     raise ValueError(f"Unknown trigger type {config.trigger_type!r}")
 
 
-def _resolve_backup_path(db_path: Path, backup_path: Path) -> Path:
-    """Return the file path to use for the backup output."""
-
+def _resolve_backup_target_parts(db_path: Path, backup_path: Path) -> tuple[Path, str, str]:
     if backup_path.exists() and backup_path.is_dir():
         backup_dir = backup_path
         stem = db_path.stem
@@ -101,6 +101,13 @@ def _resolve_backup_path(db_path: Path, backup_path: Path) -> Path:
         backup_dir = backup_path.parent
         stem = backup_path.stem
         suffix = backup_path.suffix or ".db"
+    return backup_dir, stem, suffix
+
+
+def _resolve_backup_path(db_path: Path, backup_path: Path) -> Path:
+    """Return the file path to use for the backup output."""
+
+    backup_dir, stem, suffix = _resolve_backup_target_parts(db_path, backup_path)
 
     timestamp = time.strftime("%Y%m%d%H%M%S", time.gmtime())
     for attempt in range(100):
@@ -118,24 +125,75 @@ def _resolve_backup_path(db_path: Path, backup_path: Path) -> Path:
     )
 
 
+def _pending_marker_path(db_path: Path, backup_dir: Path) -> Path:
+    return backup_dir / f"{db_path.stem}.backup-pending.json"
+
+
+def _load_pending_marker(path: Path) -> tuple[Path, Path] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    temp = payload.get("temp")
+    final = payload.get("final")
+    if not isinstance(temp, str) or not isinstance(final, str):
+        return None
+    return Path(temp), Path(final)
+
+
+def _write_pending_marker(path: Path, temp_path: Path, final_path: Path) -> None:
+    payload = {"temp": str(temp_path), "final": str(final_path)}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def _quote_identifier(identifier: str) -> str:
     return '"' + identifier.replace('"', '""') + '"'
 
 
+def _execute_with_retry(
+    connection: sqlite3.Connection,
+    statement: str,
+    parameters: tuple | list | None = None,
+    *,
+    max_attempts: int = 5,
+    base_sleep_seconds: float = 0.1,
+) -> None:
+    for attempt in range(1, max_attempts + 1):
+        try:
+            connection.execute(statement, parameters or ())
+            return
+        except sqlite3.OperationalError as exc:
+            if "database is locked" not in str(exc).lower() or attempt == max_attempts:
+                raise
+            delay = base_sleep_seconds * (2 ** (attempt - 1))
+            logger.warning(
+                "SQLite database locked while executing %s; retrying in %.2fs",
+                statement,
+                delay,
+            )
+            time.sleep(delay)
+
+
 def _cleanup_sqlite_database(connection: sqlite3.Connection) -> None:
     foreign_keys_enabled = connection.execute("PRAGMA foreign_keys").fetchone()[0]
+    connection.execute("PRAGMA busy_timeout = 5000")
     connection.execute("PRAGMA foreign_keys = OFF")
     try:
         rows = connection.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
         ).fetchall()
         for (table_name,) in rows:
-            connection.execute(f"DELETE FROM {_quote_identifier(table_name)}")
+            _execute_with_retry(
+                connection,
+                f"DELETE FROM {_quote_identifier(table_name)}",
+            )
         sequence_present = connection.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'"
         ).fetchone()
         if sequence_present:
-            connection.execute("DELETE FROM sqlite_sequence")
+            _execute_with_retry(connection, "DELETE FROM sqlite_sequence")
     finally:
         if foreign_keys_enabled:
             connection.execute("PRAGMA foreign_keys = ON")
@@ -151,16 +209,84 @@ def perform_sqlite_backup(
 
     if not db_path.exists():
         raise FileNotFoundError(f"SQLite database not found at {db_path}")
+    backup_dir, _, _ = _resolve_backup_target_parts(db_path, backup_path)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    pending_marker = _pending_marker_path(db_path, backup_dir)
+    pending_info = _load_pending_marker(pending_marker) if pending_marker.exists() else None
+
+    def _cleanup_with_retry(connection: sqlite3.Connection) -> None:
+        if not cleanup_after_backup:
+            return
+        for cleanup_attempt in range(1, 6):
+            try:
+                _cleanup_sqlite_database(connection)
+                connection.commit()
+                return
+            except sqlite3.OperationalError as exc:
+                if "database is locked" not in str(exc).lower():
+                    raise
+                if cleanup_attempt >= 5:
+                    raise
+                delay = 0.2 * cleanup_attempt
+                logger.warning(
+                    "SQLite cleanup locked; retrying in %.1fs",
+                    delay,
+                )
+                time.sleep(delay)
+
+    def _finalize_pending(temp_path: Path, final_path: Path) -> None:
+        for lock_attempt in range(1, 11):
+            try:
+                with sqlite_write_lock(db_path):
+                    connection = sqlite3.connect(db_path, timeout=30)
+                    try:
+                        _cleanup_with_retry(connection)
+                    finally:
+                        connection.close()
+                temp_path.replace(final_path)
+                pending_marker.unlink(missing_ok=True)
+                return
+            except DatabaseLockedError:
+                if lock_attempt >= 10:
+                    raise
+                delay = 0.5 * lock_attempt
+                logger.warning(
+                    "SQLite write lock busy while finalizing backup; retrying in %.1fs",
+                    delay,
+                )
+                time.sleep(delay)
+
+    if pending_info:
+        temp_path, final_path = pending_info
+        if temp_path.exists():
+            _finalize_pending(temp_path, final_path)
+            return
+        pending_marker.unlink(missing_ok=True)
+
     backup_file = _resolve_backup_path(db_path, backup_path)
-    backup_file.parent.mkdir(parents=True, exist_ok=True)
-    connection = sqlite3.connect(db_path, timeout=30)
-    try:
-        connection.execute("VACUUM INTO ?", (str(backup_file),))
-        if cleanup_after_backup:
-            _cleanup_sqlite_database(connection)
-            connection.commit()
-    finally:
-        connection.close()
+    temp_file = backup_file.with_suffix(backup_file.suffix + ".partial")
+    for attempt in range(1, 11):
+        try:
+            with sqlite_write_lock(db_path):
+                connection = sqlite3.connect(db_path, timeout=30)
+                try:
+                    connection.execute("VACUUM INTO ?", (str(temp_file),))
+                    _write_pending_marker(pending_marker, temp_file, backup_file)
+                    _cleanup_with_retry(connection)
+                finally:
+                    connection.close()
+            temp_file.replace(backup_file)
+            pending_marker.unlink(missing_ok=True)
+            return
+        except DatabaseLockedError:
+            if attempt >= 10:
+                raise
+            delay = 0.5 * attempt
+            logger.warning(
+                "SQLite write lock busy while backing up; retrying in %.1fs",
+                delay,
+            )
+            time.sleep(delay)
 
 
 class BackupScheduler:

--- a/evaluations/game_database.py
+++ b/evaluations/game_database.py
@@ -15,7 +15,7 @@ from typing import Dict, Iterable, MutableMapping
 
 from rpg.game_state import ActionAttempt, GameState
 
-from .sqlite3_connector import SQLiteConnector, sanitize_identifier
+from .sqlite3_connector import DatabaseLockedError, SQLiteConnector, sanitize_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +86,11 @@ class GameDatabaseRecorder(GameRunObserver):
         self._log_warning_count: int = 0
         self._log_error_count: int = 0
         self._current_conversation_id: str | None = None
+        self._skip_writes = False
+
+    def _handle_db_lock(self, message: str, *args: object) -> None:
+        self._skip_writes = True
+        logger.warning(message, *args)
 
     @property
     def execution_id(self) -> str | None:
@@ -106,6 +111,8 @@ class GameDatabaseRecorder(GameRunObserver):
         log_filename: str,
         session_id: str | None = None,
     ) -> None:
+        if self._skip_writes:
+            return
         self._faction_triplet_counts = {
             faction: len(scores)
             for faction, scores in state.progress.items()
@@ -113,7 +120,13 @@ class GameDatabaseRecorder(GameRunObserver):
         credibility_snapshot = state.credibility.snapshot()
         player_row = credibility_snapshot.get(state.player_faction, {})
         self._cached_credibility_targets = list(player_row.keys())
-        self._connector.initialise()
+        try:
+            self._connector.initialise()
+        except DatabaseLockedError:
+            self._handle_db_lock(
+                "SQLite database write skipped during backup lock for game start"
+            )
+            return
         self._connector.ensure_columns(
             "executions",
             {
@@ -176,17 +189,27 @@ class GameDatabaseRecorder(GameRunObserver):
             or f"{player_key}-game-{game_index}-{datetime.now(timezone.utc).isoformat()}",
         }
         metadata = {key: value for key, value in metadata.items() if value is not None}
-        self._execution_id = self._connector.insert_execution(metadata)
-        self._connector.commit()
+        try:
+            self._execution_id = self._connector.insert_execution(metadata)
+            self._connector.commit()
+        except DatabaseLockedError:
+            self._handle_db_lock(
+                "SQLite database write skipped during backup lock for game start"
+            )
+            return
         self._result_recorded = False
         self._log_filename = log_filename
         self._log_warning_count = 0
         self._log_error_count = 0
 
     def before_turn(self, state: GameState, round_index: int) -> None:
+        if self._skip_writes:
+            return
         self._pre_turn_snapshot = self._snapshot_progress(state)
 
     def after_turn(self, state: GameState, round_index: int) -> None:
+        if self._skip_writes:
+            return
         if self._execution_id is None:
             return
         attempt = state.last_action_attempt
@@ -194,6 +217,12 @@ class GameDatabaseRecorder(GameRunObserver):
             return
         try:
             action_id = self._record_action(state, attempt, round_index)
+        except DatabaseLockedError:
+            self._handle_db_lock(
+                "SQLite database write skipped during backup lock for execution %s",
+                self._execution_id,
+            )
+            return
         except sqlite3.IntegrityError:
             logger.exception(
                 "Failed to record action for execution %s; skipping turn persistence",
@@ -204,6 +233,12 @@ class GameDatabaseRecorder(GameRunObserver):
         try:
             self._record_assessment(state, action_id)
             self._record_credibility(state, attempt, action_id)
+        except DatabaseLockedError:
+            self._handle_db_lock(
+                "SQLite database write skipped during backup lock for execution %s",
+                self._execution_id,
+            )
+            return
         except sqlite3.Error:
             logger.exception(
                 "Failed to record assessment/credibility for execution %s action %s",
@@ -212,6 +247,12 @@ class GameDatabaseRecorder(GameRunObserver):
             )
         try:
             self._connector.commit()
+        except DatabaseLockedError:
+            self._handle_db_lock(
+                "SQLite database write skipped during backup lock for execution %s",
+                self._execution_id,
+            )
+            return
         except sqlite3.Error:
             logger.exception(
                 "Failed to commit turn persistence for execution %s action %s",
@@ -230,15 +271,24 @@ class GameDatabaseRecorder(GameRunObserver):
         log_warning_count: int = 0,
         log_error_count: int = 0,
     ) -> None:
+        if self._skip_writes:
+            self._reset()
+            return
         if self._execution_id is not None:
             self._log_warning_count = log_warning_count
             self._log_error_count = log_error_count
-            self._record_result(
-                successful_execution=successful,
-                result=result,
-                error_info=error,
-            )
-            self._connector.commit()
+            try:
+                self._record_result(
+                    successful_execution=successful,
+                    result=result,
+                    error_info=error,
+                )
+                self._connector.commit()
+            except DatabaseLockedError:
+                self._handle_db_lock(
+                    "SQLite database write skipped during backup lock for execution %s",
+                    self._execution_id,
+                )
         self._reset()
 
     def on_game_error(
@@ -249,17 +299,26 @@ class GameDatabaseRecorder(GameRunObserver):
         log_warning_count: int = 0,
         log_error_count: int = 0,
     ) -> None:
+        if self._skip_writes:
+            self._reset()
+            return
         if self._execution_id is None:
             self._reset()
             return
         self._log_warning_count = log_warning_count
         self._log_error_count = log_error_count
-        self._record_result(
-            successful_execution=False,
-            result="N/A",
-            error_info=str(error),
-        )
-        self._connector.commit()
+        try:
+            self._record_result(
+                successful_execution=False,
+                result="N/A",
+                error_info=str(error),
+            )
+            self._connector.commit()
+        except DatabaseLockedError:
+            self._handle_db_lock(
+                "SQLite database write skipped during backup lock for execution %s",
+                self._execution_id,
+            )
         self._reset()
 
     # Internal helpers ---------------------------------------------------
@@ -372,6 +431,7 @@ class GameDatabaseRecorder(GameRunObserver):
         self._log_warning_count = 0
         self._log_error_count = 0
         self._current_conversation_id = None
+        self._skip_writes = False
 
 
 __all__ = ["GameRunObserver", "GameDatabaseRecorder"]

--- a/evaluations/player_service.py
+++ b/evaluations/player_service.py
@@ -42,7 +42,11 @@ from evaluations.players import (
     Player,
     RandomPlayer,
 )
-from evaluations.sqlite3_connector import DatabaseLockedError, SQLiteConnector
+from evaluations.sqlite3_connector import (
+    DatabaseLockedError,
+    SQLiteConnector,
+    is_sqlite_write_locked,
+)
 from rpg.assessment_agent import AssessmentAgent
 from rpg.config import load_game_config
 
@@ -397,6 +401,12 @@ def create_app(log_dir: str | None = None) -> Flask:
                         _state, _player_instance, selected_key, game_number
                     ):
                         notes = f"{selected_key}-{scenario_key}-game-{game_number}"
+                        if is_sqlite_write_locked():
+                            logger.warning(
+                                "SQLite backup lock active; skipping DB logging for %s",
+                                notes,
+                            )
+                            return None
                         try:
                             connector = SQLiteConnector()
                         except DatabaseLockedError:

--- a/evaluations/sqlite3_connector.py
+++ b/evaluations/sqlite3_connector.py
@@ -10,6 +10,7 @@ import os
 import re
 import sqlite3
 import threading
+import time
 import uuid
 from contextlib import contextmanager
 from dataclasses import asdict, is_dataclass
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 _DDL_PATH = Path(__file__).with_name("sqlite3_db.ddl")
 _DB_PATH_ENV = "EVALUATION_SQLITE_PATH"
 _DEFAULT_DB_PATH = Path("/var/lib/sqlite/main.db")
+_WRITE_LOCK_HELD = threading.Event()
 
 
 def _default_db_path_from_env() -> Path:
@@ -80,6 +82,10 @@ class SQLiteConnector:
     def _acquire_interprocess_lock(self) -> None:
         if not self.require_lock:
             return
+        if _WRITE_LOCK_HELD.is_set():
+            raise DatabaseLockedError(
+                f"Database locked via {self.lock_path}; backup write lock active"
+            )
         if self._blocked_by_lock:
             raise DatabaseLockedError(
                 f"Database locked via {self.lock_path}; another container is writing"
@@ -341,4 +347,73 @@ def sqlite_connector(db_path: Path | str | None = None) -> Iterator[SQLiteConnec
         connector.close()
 
 
-__all__ = ["DatabaseLockedError", "SQLiteConnector", "sqlite_connector", "sanitize_identifier"]
+@contextmanager
+def sqlite_write_lock(
+    db_path: Path | str | None = None,
+    lock_path: Path | str | None = None,
+    *,
+    timeout_seconds: float = 10.0,
+    poll_interval_seconds: float = 0.1,
+) -> Iterator[None]:
+    resolved_db_path = Path(db_path) if db_path else _default_db_path_from_env()
+    resolved_lock_path = Path(
+        lock_path
+        or (resolved_db_path.with_suffix(resolved_db_path.suffix + ".lock"))
+    )
+    _ensure_directory(resolved_lock_path)
+    logger.info("Attempting to acquire SQLite write lock at %s", resolved_lock_path)
+    fd = os.open(resolved_lock_path, os.O_RDWR | os.O_CREAT)
+    file_handle = os.fdopen(fd, "r+")
+    try:
+        start = time.monotonic()
+        while True:
+            try:
+                if fcntl is not None:
+                    fcntl.flock(file_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                file_handle.seek(0)
+                file_handle.truncate()
+                file_handle.write("1")
+                file_handle.flush()
+                os.fsync(file_handle.fileno())
+                break
+            except OSError as exc:  # pragma: no cover - depends on runtime
+                if fcntl is None:
+                    raise
+                if time.monotonic() - start >= timeout_seconds:
+                    raise DatabaseLockedError(
+                        f"Database locked via {resolved_lock_path}; another writer is active"
+                    ) from exc
+                time.sleep(poll_interval_seconds)
+        _WRITE_LOCK_HELD.set()
+        logger.info("Acquired SQLite write lock at %s", resolved_lock_path)
+        yield
+    finally:
+        try:
+            file_handle.seek(0)
+            file_handle.truncate()
+            file_handle.write("0")
+            file_handle.flush()
+            os.fsync(file_handle.fileno())
+            if fcntl is not None:
+                try:
+                    fcntl.flock(file_handle, fcntl.LOCK_UN)
+                except OSError:  # pragma: no cover - depends on runtime
+                    pass
+        finally:
+            file_handle.close()
+            _WRITE_LOCK_HELD.clear()
+            logger.info("Released SQLite write lock at %s", resolved_lock_path)
+
+
+def is_sqlite_write_locked() -> bool:
+    return _WRITE_LOCK_HELD.is_set()
+
+
+__all__ = [
+    "DatabaseLockedError",
+    "SQLiteConnector",
+    "is_sqlite_write_locked",
+    "sqlite_connector",
+    "sqlite_write_lock",
+    "sanitize_identifier",
+]

--- a/tests/test_backup_scheduler.py
+++ b/tests/test_backup_scheduler.py
@@ -3,14 +3,22 @@
 import os
 import sqlite3
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from evaluations.backup_scheduler import (
     BackupScheduler,
     ClosedSessionsThresholdCondition,
+    _execute_with_retry,
     perform_sqlite_backup,
+)
+from evaluations.sqlite3_connector import (
+    DatabaseLockedError,
+    SQLiteConnector,
+    sqlite_write_lock,
 )
 from rpg.session_monitor import SessionActivityMonitor
 
@@ -46,6 +54,111 @@ def test_perform_sqlite_backup_cleans_up_db(tmp_path):
 
     assert tables == [("test_table",)]
     assert rows == []
+
+
+def test_perform_sqlite_backup_retries_cleanup_on_lock(tmp_path):
+    db_path = tmp_path / "game.sqlite"
+    backup_dir = tmp_path / "backups"
+    connection = sqlite3.connect(db_path)
+    connection.execute("CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT)")
+    connection.execute("INSERT INTO test_table (name) VALUES ('Ada')")
+    connection.commit()
+    connection.close()
+
+    import evaluations.backup_scheduler as backup_scheduler
+
+    original_cleanup = backup_scheduler._cleanup_sqlite_database
+    attempts = {"count": 0}
+
+    def flaky_cleanup(connection):
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise sqlite3.OperationalError("database is locked")
+        return original_cleanup(connection)
+
+    with patch(
+        "evaluations.backup_scheduler._cleanup_sqlite_database",
+        side_effect=flaky_cleanup,
+    ):
+        perform_sqlite_backup(db_path, backup_dir, cleanup_after_backup=True)
+
+    connection = sqlite3.connect(db_path)
+    rows = connection.execute("SELECT * FROM test_table").fetchall()
+    connection.close()
+
+    assert rows == []
+
+
+def test_backup_uses_single_backup_file_after_cleanup_retry(tmp_path):
+    db_path = tmp_path / "game.sqlite"
+    backup_dir = tmp_path / "backups"
+    connection = sqlite3.connect(db_path)
+    connection.execute("CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT)")
+    connection.execute("INSERT INTO test_table (name) VALUES ('Ada')")
+    connection.commit()
+    connection.close()
+
+    import evaluations.backup_scheduler as backup_scheduler
+
+    original_cleanup = backup_scheduler._cleanup_sqlite_database
+
+    def always_locked(_connection):
+        raise sqlite3.OperationalError("database is locked")
+
+    with patch(
+        "evaluations.backup_scheduler._cleanup_sqlite_database",
+        side_effect=always_locked,
+    ):
+        with pytest.raises(sqlite3.OperationalError):
+            perform_sqlite_backup(db_path, backup_dir, cleanup_after_backup=True)
+
+    assert list(backup_dir.glob("game-*.db")) == []
+    pending_files = list(backup_dir.glob("game.backup-pending.json"))
+    assert len(pending_files) == 1
+    temp_files = list(backup_dir.glob("game-*.db.partial"))
+    assert len(temp_files) == 1
+
+    with patch(
+        "evaluations.backup_scheduler._cleanup_sqlite_database",
+        side_effect=original_cleanup,
+    ):
+        perform_sqlite_backup(db_path, backup_dir, cleanup_after_backup=True)
+
+    backup_files = list(backup_dir.glob("game-*.db"))
+    assert len(backup_files) == 1
+    assert list(backup_dir.glob("game.backup-pending.json")) == []
+
+
+def test_execute_with_retry_retries_on_locked_database():
+    connection = MagicMock()
+    connection.execute.side_effect = [
+        sqlite3.OperationalError("database is locked"),
+        None,
+    ]
+
+    _execute_with_retry(connection, "DELETE FROM test_table", max_attempts=2, base_sleep_seconds=0)
+
+    assert connection.execute.call_count == 2
+
+
+def test_sqlite_write_lock_blocks_connector(tmp_path):
+    db_path = tmp_path / "game.sqlite"
+    sqlite3.connect(db_path).close()
+
+    with sqlite_write_lock(db_path):
+        connector = SQLiteConnector(db_path=db_path)
+        with pytest.raises(DatabaseLockedError):
+            connector.initialise()
+
+
+def test_perform_sqlite_backup_respects_write_lock(tmp_path):
+    db_path = tmp_path / "game.sqlite"
+    backup_dir = tmp_path / "backups"
+    sqlite3.connect(db_path).close()
+
+    with sqlite_write_lock(db_path):
+        with pytest.raises(DatabaseLockedError):
+            perform_sqlite_backup(db_path, backup_dir)
 
 
 def test_backup_scheduler_skips_when_active_sessions(tmp_path):

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -54,6 +54,7 @@ def test_async_response_generation(mock_char_genai, mock_assess_genai):
         *,
         partner_credibility=None,
         conversation_cache=None,
+        raw_response_callback=None,
     ):
         start_evt.set()
         finish_evt.wait()
@@ -101,6 +102,7 @@ def test_async_npc_responses(mock_char_genai, mock_assess_genai):
         *,
         partner_credibility=None,
         conversation_cache=None,
+        raw_response_callback=None,
     ):
         return [
             ResponseOption(text="Starter 1", type="chat"),
@@ -118,6 +120,7 @@ def test_async_npc_responses(mock_char_genai, mock_assess_genai):
         *,
         partner_credibility=None,
         conversation_cache=None,
+        raw_response_callback=None,
         force_action=False,
     ):
         start_evt.set()
@@ -188,6 +191,7 @@ def test_assessment_background_wait(mock_char_genai, mock_assess_genai):
         *,
         partner_credibility=None,
         conversation_cache=None,
+        raw_response_callback=None,
     ):
         return [action_option]
 

--- a/web_service.py
+++ b/web_service.py
@@ -32,7 +32,11 @@ from evaluations.backup_scheduler import (
     load_backup_scheduler_config,
 )
 from evaluations.game_database import GameDatabaseRecorder
-from evaluations.sqlite3_connector import DatabaseLockedError, SQLiteConnector
+from evaluations.sqlite3_connector import (
+    DatabaseLockedError,
+    SQLiteConnector,
+    is_sqlite_write_locked,
+)
 from cli_game import load_characters
 from rpg.assessment_agent import AssessmentAgent
 from rpg.character import Character, ResponseOption
@@ -621,11 +625,21 @@ def create_app() -> Flask:
         nonlocal db_connector_shared, db_logging_available
         if not db_logging_available:
             return None
+        if is_sqlite_write_locked():
+            logger.warning(
+                "SQLite backup lock active; skipping web session DB logging setup",
+            )
+            return None
         if db_connector_shared is not None:
             return db_connector_shared
         with db_connector_lock:
             if db_connector_shared is not None:
                 return db_connector_shared
+            if is_sqlite_write_locked():
+                logger.warning(
+                    "SQLite backup lock active; skipping web session DB logging setup",
+                )
+                return None
             try:
                 candidate = SQLiteConnector()
             except DatabaseLockedError:


### PR DESCRIPTION
### Motivation
- Ensure a single finalized backup is produced per backup trigger even if cleanup retries or transient locks occur.
- Prevent multiple successful VACUUM outputs when cleanup fails due to transient `database is locked` errors.
- Provide an application-level write lock so other parts of the app can detect and avoid DB writes during backups.
- Retry cleanup statements and backoff when SQLite reports file locks to improve robustness.

### Description
- Introduce a pending-marker flow: write a `.partial` temp backup and a `*.backup-pending.json` marker and finalize the pending backup on the next run instead of creating another backup file. 
- Add `_execute_with_retry` and set `PRAGMA busy_timeout = 5000` in `_cleanup_sqlite_database` to retry `DELETE` statements on lock with exponential backoff. 
- Add `sqlite_write_lock` context manager and `is_sqlite_write_locked` helper in `evaluations.sqlite3_connector` using a process lock file and an internal `_WRITE_LOCK_HELD` flag, and raise `DatabaseLockedError` when appropriate. 
- Make `GameDatabaseRecorder` detect `DatabaseLockedError`, flip a `_skip_writes` flag to skip subsequent writes, and update `web_service` and `player_service` to check `is_sqlite_write_locked()` and avoid setting up DB logging during backups. 
- Add tests in `tests/test_backup_scheduler.py` covering pending-marker behavior, retry logic, `sqlite_write_lock`, and `_execute_with_retry`, and update parallel tests to accept the new callback argument.

### Testing
- Ran `pytest`; the run was interrupted via `KeyboardInterrupt` after ~12 minutes but executed tests until interruption. 
- `pytest` reported `37 passed` and several warnings before interruption. 
- New and modified tests exercise the pending-marker and retry paths including `test_backup_uses_single_backup_file_after_cleanup_retry`, `test_execute_with_retry_retries_on_locked_database`, and `test_sqlite_write_lock_blocks_connector` which passed in the run. 
- No new failing automated tests were observed in the executed portion of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a52af8af083338dc270e8c1cc66d3)